### PR TITLE
feat: add file-level import graph extraction (Phase 1)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,7 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
         "babel-plugin-react-compiler": "^1.0.0",
+        "bun-types": "^1.3.8",
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
         "wrangler": "^3.105.0",
@@ -319,6 +320,8 @@
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 

--- a/graph/src/cli.ts
+++ b/graph/src/cli.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env bun
+import path from "path";
+import { extractFileGraph } from "./extract.ts";
+
+const tsconfigArg = process.argv[2];
+
+if (!tsconfigArg) {
+  console.error("Usage: bun graph/src/cli.ts <path-to-tsconfig.json>");
+  process.exit(1);
+}
+
+const tsconfigPath = path.resolve(tsconfigArg);
+const edges = extractFileGraph(tsconfigPath);
+
+console.log(JSON.stringify(edges, null, 2));

--- a/graph/src/extract.ts
+++ b/graph/src/extract.ts
@@ -1,0 +1,235 @@
+import ts from "typescript";
+import path from "path";
+import type { FileEdge } from "./types.ts";
+
+/**
+ * Extract the file-level import graph from a TypeScript project.
+ *
+ * Walks every source file in the program, extracts static and dynamic imports,
+ * resolves specifiers to absolute file paths, and captures imported symbol names.
+ */
+export function extractFileGraph(tsconfigPath: string): FileEdge[] {
+  const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+  if (configFile.error) {
+    const msg = ts.flattenDiagnosticMessageText(
+      configFile.error.messageText,
+      "\n",
+    );
+    throw new Error(`Failed to read tsconfig: ${msg}`);
+  }
+
+  const basePath = path.dirname(path.resolve(tsconfigPath));
+  const parsed = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    basePath,
+  );
+  if (parsed.errors.length > 0) {
+    const msg = parsed.errors
+      .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"))
+      .join("\n");
+    throw new Error(`Failed to parse tsconfig: ${msg}`);
+  }
+
+  const program = ts.createProgram(parsed.fileNames, parsed.options);
+  const checker = program.getTypeChecker();
+  const edges: FileEdge[] = [];
+
+  for (const sourceFile of program.getSourceFiles()) {
+    // Skip declaration files and files outside the project (node_modules, etc.)
+    if (sourceFile.isDeclarationFile) continue;
+    if (sourceFile.fileName.includes("node_modules")) continue;
+
+    const fromPath = path.resolve(sourceFile.fileName);
+    collectImports(sourceFile, fromPath, program, checker, edges);
+  }
+
+  return edges;
+}
+
+/**
+ * Collect all imports from a single source file by walking its AST.
+ */
+function collectImports(
+  sourceFile: ts.SourceFile,
+  fromPath: string,
+  program: ts.Program,
+  checker: ts.TypeChecker,
+  edges: FileEdge[],
+): void {
+  ts.forEachChild(sourceFile, function visit(node) {
+    // Static import declarations: import { foo } from "./bar"
+    if (ts.isImportDeclaration(node)) {
+      handleImportDeclaration(node, fromPath, program, edges);
+    }
+    // Static export declarations: export { foo } from "./bar"
+    else if (ts.isExportDeclaration(node)) {
+      handleExportDeclaration(node, fromPath, program, edges);
+    }
+    // Dynamic import(): const m = import("./bar")
+    else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword
+    ) {
+      handleDynamicImport(node, fromPath, sourceFile, program, edges);
+    }
+
+    ts.forEachChild(node, visit);
+  });
+}
+
+/**
+ * Handle a static import declaration.
+ *
+ * Covers:
+ *  - import { a, b } from "./mod"
+ *  - import { a as x } from "./mod"
+ *  - import defaultExport from "./mod"
+ *  - import * as ns from "./mod"
+ *  - import "./mod" (side-effect)
+ */
+function handleImportDeclaration(
+  node: ts.ImportDeclaration,
+  fromPath: string,
+  program: ts.Program,
+  edges: FileEdge[],
+): void {
+  if (!ts.isStringLiteral(node.moduleSpecifier)) return;
+
+  const specifier = node.moduleSpecifier.text;
+  const resolved = resolveModuleSpecifier(
+    specifier,
+    fromPath,
+    program.getCompilerOptions(),
+  );
+  if (!resolved) return;
+
+  const symbols: string[] = [];
+  const importClause = node.importClause;
+
+  if (importClause) {
+    // Default import: import Foo from "./bar"
+    if (importClause.name) {
+      symbols.push(importClause.name.text);
+    }
+
+    const bindings = importClause.namedBindings;
+    if (bindings) {
+      if (ts.isNamedImports(bindings)) {
+        // Named imports: import { a, b as c } from "./bar"
+        for (const el of bindings.elements) {
+          // Use the original exported name, not the local alias
+          symbols.push((el.propertyName ?? el.name).text);
+        }
+      } else if (ts.isNamespaceImport(bindings)) {
+        // Namespace import: import * as ns from "./bar"
+        symbols.push(`* as ${bindings.name.text}`);
+      }
+    }
+  }
+  // If no importClause, it's a side-effect import: import "./bar"
+  // We still record the edge with an empty symbols array.
+
+  edges.push({ from: fromPath, to: resolved, symbols });
+}
+
+/**
+ * Handle a re-export declaration.
+ *
+ * Covers:
+ *  - export { a, b } from "./mod"
+ *  - export * from "./mod"
+ *  - export * as ns from "./mod"
+ */
+function handleExportDeclaration(
+  node: ts.ExportDeclaration,
+  fromPath: string,
+  program: ts.Program,
+  edges: FileEdge[],
+): void {
+  if (!node.moduleSpecifier || !ts.isStringLiteral(node.moduleSpecifier))
+    return;
+
+  const specifier = node.moduleSpecifier.text;
+  const resolved = resolveModuleSpecifier(
+    specifier,
+    fromPath,
+    program.getCompilerOptions(),
+  );
+  if (!resolved) return;
+
+  const symbols: string[] = [];
+  const exportClause = node.exportClause;
+
+  if (exportClause) {
+    if (ts.isNamedExports(exportClause)) {
+      for (const el of exportClause.elements) {
+        symbols.push((el.propertyName ?? el.name).text);
+      }
+    } else if (ts.isNamespaceExport(exportClause)) {
+      symbols.push(`* as ${exportClause.name.text}`);
+    }
+  } else {
+    // export * from "./mod" — barrel re-export
+    symbols.push("*");
+  }
+
+  edges.push({ from: fromPath, to: resolved, symbols });
+}
+
+/**
+ * Handle a dynamic import() call.
+ *
+ * Extracts the module specifier if it's a string literal.
+ * Dynamic imports with non-literal specifiers are skipped.
+ */
+function handleDynamicImport(
+  node: ts.CallExpression,
+  fromPath: string,
+  sourceFile: ts.SourceFile,
+  program: ts.Program,
+  edges: FileEdge[],
+): void {
+  const arg = node.arguments[0];
+  if (!arg || !ts.isStringLiteral(arg)) return;
+
+  const specifier = arg.text;
+  const resolved = resolveModuleSpecifier(
+    specifier,
+    fromPath,
+    program.getCompilerOptions(),
+  );
+  if (!resolved) return;
+
+  // Dynamic imports don't have a static symbol list at the import site.
+  // The symbols are accessed at runtime via the returned module object.
+  edges.push({ from: fromPath, to: resolved, symbols: ["<dynamic>"] });
+}
+
+/**
+ * Resolve an import specifier to an absolute file path using the TypeScript
+ * module resolution algorithm. Respects tsconfig paths, baseUrl, etc.
+ *
+ * Returns null for unresolvable specifiers (e.g. bare node_modules packages
+ * that don't resolve to project source files).
+ */
+function resolveModuleSpecifier(
+  specifier: string,
+  containingFile: string,
+  options: ts.CompilerOptions,
+): string | null {
+  const result = ts.resolveModuleName(
+    specifier,
+    containingFile,
+    options,
+    ts.sys,
+  );
+
+  const resolved = result.resolvedModule;
+  if (!resolved) return null;
+
+  // Skip external node_modules — we only care about project source files
+  if (resolved.isExternalLibraryImport) return null;
+
+  return path.resolve(resolved.resolvedFileName);
+}

--- a/graph/src/index.ts
+++ b/graph/src/index.ts
@@ -1,0 +1,2 @@
+export { extractFileGraph } from "./extract.ts";
+export type { FileEdge } from "./types.ts";

--- a/graph/src/types.ts
+++ b/graph/src/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Represents a single import relationship between two source files.
+ */
+export interface FileEdge {
+  /** Absolute path of the importing file. */
+  from: string;
+  /** Absolute path of the imported file. */
+  to: string;
+  /** Named imports crossing this edge (e.g. ["createUser", "UserSchema"]). */
+  symbols: string[];
+}

--- a/graph/test/extract.test.ts
+++ b/graph/test/extract.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect } from "bun:test";
+import path from "path";
+import { extractFileGraph } from "../src/extract.ts";
+import type { FileEdge } from "../src/types.ts";
+
+const fixturesDir = path.resolve(import.meta.dir, "fixtures");
+const tsconfigPath = path.join(fixturesDir, "tsconfig.json");
+
+function findEdge(
+  edges: FileEdge[],
+  fromFile: string,
+  toFile: string,
+): FileEdge | undefined {
+  const fromPath = path.join(fixturesDir, fromFile);
+  const toPath = path.join(fixturesDir, toFile);
+  return edges.find((e) => e.from === fromPath && e.to === toPath);
+}
+
+describe("extractFileGraph", () => {
+  const edges = extractFileGraph(tsconfigPath);
+
+  test("extracts named imports", () => {
+    const edge = findEdge(edges, "service.ts", "models.ts");
+    expect(edge).toBeDefined();
+    expect(edge!.symbols).toContain("User");
+    expect(edge!.symbols).toContain("Order");
+  });
+
+  test("extracts aliased imports using original name", () => {
+    const edge = findEdge(edges, "service.ts", "utils.ts");
+    // Should use the original exported name "formatName", not the alias "fmt"
+    expect(edge).toBeDefined();
+    const utilsEdges = edges.filter(
+      (e) =>
+        e.from === path.join(fixturesDir, "service.ts") &&
+        e.to === path.join(fixturesDir, "utils.ts"),
+    );
+    const allSymbols = utilsEdges.flatMap((e) => e.symbols);
+    expect(allSymbols).toContain("formatName");
+  });
+
+  test("extracts namespace imports", () => {
+    const utilsEdges = edges.filter(
+      (e) =>
+        e.from === path.join(fixturesDir, "service.ts") &&
+        e.to === path.join(fixturesDir, "utils.ts"),
+    );
+    const allSymbols = utilsEdges.flatMap((e) => e.symbols);
+    expect(allSymbols).toContain("* as Utils");
+  });
+
+  test("extracts side-effect imports with empty symbols", () => {
+    const edge = findEdge(edges, "service.ts", "side-effect.ts");
+    expect(edge).toBeDefined();
+    expect(edge!.symbols).toEqual([]);
+  });
+
+  test("extracts barrel re-exports (export * from)", () => {
+    const edge = findEdge(edges, "barrel.ts", "models.ts");
+    expect(edge).toBeDefined();
+    expect(edge!.symbols).toContain("*");
+  });
+
+  test("extracts named re-exports (export { x } from)", () => {
+    const edge = findEdge(edges, "barrel.ts", "utils.ts");
+    expect(edge).toBeDefined();
+    expect(edge!.symbols).toContain("formatName");
+  });
+
+  test("extracts dynamic import() calls", () => {
+    const edge = findEdge(edges, "lazy.ts", "service.ts");
+    expect(edge).toBeDefined();
+    expect(edge!.symbols).toContain("<dynamic>");
+  });
+
+  test("does not include edges to node_modules", () => {
+    const externalEdges = edges.filter((e) =>
+      e.to.includes("node_modules"),
+    );
+    expect(externalEdges).toHaveLength(0);
+  });
+
+  test("uses absolute paths", () => {
+    for (const edge of edges) {
+      expect(path.isAbsolute(edge.from)).toBe(true);
+      expect(path.isAbsolute(edge.to)).toBe(true);
+    }
+  });
+});

--- a/graph/test/fixtures/barrel.ts
+++ b/graph/test/fixtures/barrel.ts
@@ -1,0 +1,2 @@
+export * from "./models.ts";
+export { formatName } from "./utils.ts";

--- a/graph/test/fixtures/lazy.ts
+++ b/graph/test/fixtures/lazy.ts
@@ -1,0 +1,5 @@
+// Dynamic import
+export async function loadService() {
+  const mod = await import("./service.ts");
+  return mod.createUser("test");
+}

--- a/graph/test/fixtures/models.ts
+++ b/graph/test/fixtures/models.ts
@@ -1,0 +1,11 @@
+export interface User {
+  id: string;
+  name: string;
+}
+
+export interface Order {
+  id: string;
+  userId: string;
+}
+
+export const DEFAULT_PAGE_SIZE = 20;

--- a/graph/test/fixtures/service.ts
+++ b/graph/test/fixtures/service.ts
@@ -1,0 +1,17 @@
+// Named imports
+import { User, Order } from "./models.ts";
+// Aliased import
+import { formatName as fmt } from "./utils.ts";
+// Namespace import
+import * as Utils from "./utils.ts";
+// Side-effect import
+import "./side-effect.ts";
+
+export function createUser(name: string): User {
+  return { id: "1", name: fmt("John", name) };
+}
+
+export function getOrders(): Order[] {
+  const valid = Utils.validateEmail("test@test.com");
+  return [];
+}

--- a/graph/test/fixtures/side-effect.ts
+++ b/graph/test/fixtures/side-effect.ts
@@ -1,0 +1,2 @@
+// This file is imported for its side effects only
+console.log("side effect loaded");

--- a/graph/test/fixtures/tsconfig.json
+++ b/graph/test/fixtures/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["./**/*.ts", "./**/*.tsx"]
+}

--- a/graph/test/fixtures/utils.ts
+++ b/graph/test/fixtures/utils.ts
@@ -1,0 +1,7 @@
+export function formatName(first: string, last: string): string {
+  return `${first} ${last}`;
+}
+
+export function validateEmail(email: string): boolean {
+  return email.includes("@");
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "dev": "bun run dev:worker & bun run dev:frontend",
     "build:worker": "tsc --noEmit -p tsconfig.worker.json",
     "build:frontend": "tsc --noEmit -p tsconfig.frontend.json && vite build",
-    "build": "bun run build:worker && bun run build:frontend",
+    "build:graph": "tsc --noEmit -p tsconfig.graph.json",
+    "build": "bun run build:worker && bun run build:frontend && bun run build:graph",
+    "graph": "bun graph/src/cli.ts",
+    "test": "bun test",
     "deploy": "wrangler deploy"
   },
   "dependencies": {
@@ -24,6 +27,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
     "babel-plugin-react-compiler": "^1.0.0",
+    "bun-types": "^1.3.8",
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
     "wrangler": "^3.105.0"

--- a/tsconfig.graph.json
+++ b/tsconfig.graph.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "lib": ["ESNext"],
+    "types": ["bun-types"],
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["graph/src"]
+}


### PR DESCRIPTION
Implement the TypeScript import graph extractor using the TS Compiler API.
Walks source files, extracts static/dynamic imports and re-exports, resolves
specifiers to absolute paths, and captures imported symbol names.

- graph/src/types.ts: FileEdge interface
- graph/src/extract.ts: core extraction using ts.createProgram
- graph/src/cli.ts: CLI entry point (bun run graph <tsconfig>)
- graph/src/index.ts: public API barrel
- graph/test/: test suite with fixtures covering named, aliased,
  namespace, side-effect, barrel re-export, and dynamic imports
- tsconfig.graph.json: TypeScript config for graph tool
- package.json: build:graph, graph, and test scripts; bun-types dep

https://claude.ai/code/session_01DkDvKAKRzQqeoYKHshxJ3z