### PR TITLE
feat: add group config and heuristic file classification (Phase 2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "hono": "^4.7.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "yaml": "^2.8.2",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250121.0",
@@ -590,6 +591,8 @@
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 

--- a/graph/src/classify.ts
+++ b/graph/src/classify.ts
@@ -1,0 +1,189 @@
+import path from "path";
+import fs from "fs";
+import crypto from "crypto";
+import type {
+  GroupConfig,
+  FileClassification,
+  ClassificationResult,
+} from "./types.ts";
+import { bestGroup } from "./heuristics.ts";
+
+/**
+ * Options for {@link classifyFiles}.
+ */
+export interface ClassifyOptions {
+  /** Absolute path to the project root. File paths in overrides are relative to this. */
+  projectRoot: string;
+  /** Directory to read/write the classification cache. Omit to disable caching. */
+  cacheDir?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Cache format: JSON map of relative file path → cached entry.
+// ---------------------------------------------------------------------------
+
+interface CacheEntry {
+  /** Hex SHA-256 of the file content at the time of classification. */
+  contentHash: string;
+  /** Assigned group name. */
+  group: string;
+  /** How the assignment was made. */
+  strategy: FileClassification["strategy"];
+}
+
+type CacheMap = Record<string, CacheEntry>;
+
+const CACHE_FILENAME = ".group-cache.json";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a set of source files into groups defined by `config`.
+ *
+ * Classification priority (highest → lowest):
+ * 1. Manual overrides (glob patterns pinned to groups)
+ * 2. Cached classification (content hash matches)
+ * 3. Heuristic pre-pass (directory/filename pattern matching)
+ * 4. Unclassified (for future LLM classification — Phase 4)
+ */
+export function classifyFiles(
+  files: string[],
+  config: GroupConfig,
+  options: ClassifyOptions,
+): ClassificationResult {
+  const { projectRoot, cacheDir } = options;
+  const cache = cacheDir ? loadCache(cacheDir) : {};
+  const classifications: FileClassification[] = [];
+  const unclassified: string[] = [];
+
+  for (const file of files) {
+    const abs = path.resolve(file);
+    const rel = path.relative(projectRoot, abs);
+
+    // 1. Manual override
+    const overrideGroup = matchOverride(rel, config);
+    if (overrideGroup) {
+      classifications.push({
+        file: abs,
+        group: overrideGroup,
+        strategy: "override",
+      });
+      updateCache(cache, rel, abs, overrideGroup, "override");
+      continue;
+    }
+
+    // 2. Cache hit (content hash matches)
+    const cached = lookupCache(cache, rel, abs);
+    if (cached) {
+      classifications.push({
+        file: abs,
+        group: cached.group,
+        strategy: cached.strategy,
+      });
+      continue;
+    }
+
+    // 3. Heuristic classification
+    const match = bestGroup(abs, config.groups);
+    if (match) {
+      classifications.push({
+        file: abs,
+        group: match.group,
+        strategy: "heuristic",
+      });
+      updateCache(cache, rel, abs, match.group, "heuristic");
+      continue;
+    }
+
+    // 4. Unclassified — awaiting Phase 4 LLM classification
+    unclassified.push(abs);
+  }
+
+  if (cacheDir) {
+    saveCache(cacheDir, cache);
+  }
+
+  return { classifications, unclassified };
+}
+
+// ---------------------------------------------------------------------------
+// Override matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a file's relative path matches any user-defined override pattern.
+ * Returns the group name on match, or null.
+ */
+function matchOverride(relativePath: string, config: GroupConfig): string | null {
+  if (!config.overrides || config.overrides.length === 0) return null;
+
+  // Normalise to forward slashes for consistent glob matching
+  const normalised = relativePath.replace(/\\/g, "/");
+
+  for (const override of config.overrides) {
+    const glob = new Bun.Glob(override.pattern);
+    if (glob.match(normalised)) {
+      return override.group;
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Content hash caching
+// ---------------------------------------------------------------------------
+
+function hashFile(absPath: string): string | null {
+  try {
+    const content = fs.readFileSync(absPath);
+    return crypto.createHash("sha256").update(content).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+function loadCache(cacheDir: string): CacheMap {
+  const cachePath = path.join(cacheDir, CACHE_FILENAME);
+  try {
+    const raw = fs.readFileSync(cachePath, "utf-8");
+    return JSON.parse(raw) as CacheMap;
+  } catch {
+    return {};
+  }
+}
+
+function saveCache(cacheDir: string, cache: CacheMap): void {
+  fs.mkdirSync(cacheDir, { recursive: true });
+  const cachePath = path.join(cacheDir, CACHE_FILENAME);
+  fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2));
+}
+
+function lookupCache(
+  cache: CacheMap,
+  relPath: string,
+  absPath: string,
+): CacheEntry | null {
+  const entry = cache[relPath];
+  if (!entry) return null;
+
+  const currentHash = hashFile(absPath);
+  if (!currentHash || currentHash !== entry.contentHash) return null;
+
+  return entry;
+}
+
+function updateCache(
+  cache: CacheMap,
+  relPath: string,
+  absPath: string,
+  group: string,
+  strategy: FileClassification["strategy"],
+): void {
+  const contentHash = hashFile(absPath);
+  if (!contentHash) return;
+
+  cache[relPath] = { contentHash, group, strategy };
+}

--- a/graph/src/config.ts
+++ b/graph/src/config.ts
@@ -1,0 +1,110 @@
+import fs from "fs";
+import path from "path";
+import { parse as parseYaml } from "yaml";
+import type { GroupConfig, GroupDefinition, GroupOverride } from "./types.ts";
+
+/**
+ * Load and validate a group configuration from a YAML file.
+ *
+ * Expected format:
+ * ```yaml
+ * groups:
+ *   - name: "UI Components"
+ *     description: "React components that render UI"
+ *   - name: "API Routes"
+ *     description: "HTTP endpoint handlers"
+ * overrides:           # optional
+ *   - pattern: "src/config/**"
+ *     group: "Business Logic"
+ * ```
+ */
+export function loadGroupConfig(configPath: string): GroupConfig {
+  const resolved = path.resolve(configPath);
+  const raw = fs.readFileSync(resolved, "utf-8");
+  return parseGroupConfig(raw);
+}
+
+/**
+ * Parse and validate a group configuration from a YAML string.
+ */
+export function parseGroupConfig(yaml: string): GroupConfig {
+  const doc = parseYaml(yaml);
+
+  if (!doc || typeof doc !== "object") {
+    throw new Error("Group config must be a YAML object");
+  }
+
+  const { groups, overrides } = doc as Record<string, unknown>;
+
+  if (!Array.isArray(groups) || groups.length === 0) {
+    throw new Error("Group config must define at least one group");
+  }
+
+  const parsed: GroupConfig = {
+    groups: groups.map(validateGroupDefinition),
+  };
+
+  // Validate uniqueness of group names
+  const names = new Set<string>();
+  for (const g of parsed.groups) {
+    if (names.has(g.name)) {
+      throw new Error(`Duplicate group name: "${g.name}"`);
+    }
+    names.add(g.name);
+  }
+
+  // Parse overrides if present
+  if (overrides !== undefined) {
+    if (!Array.isArray(overrides)) {
+      throw new Error('"overrides" must be an array');
+    }
+    parsed.overrides = overrides.map((o, i) =>
+      validateGroupOverride(o, i, names),
+    );
+  }
+
+  return parsed;
+}
+
+function validateGroupDefinition(raw: unknown, index: number): GroupDefinition {
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`groups[${index}] must be an object`);
+  }
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.name !== "string" || obj.name.trim() === "") {
+    throw new Error(`groups[${index}].name must be a non-empty string`);
+  }
+  if (typeof obj.description !== "string" || obj.description.trim() === "") {
+    throw new Error(`groups[${index}].description must be a non-empty string`);
+  }
+
+  return { name: obj.name.trim(), description: obj.description.trim() };
+}
+
+function validateGroupOverride(
+  raw: unknown,
+  index: number,
+  validGroups: Set<string>,
+): GroupOverride {
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`overrides[${index}] must be an object`);
+  }
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.pattern !== "string" || obj.pattern.trim() === "") {
+    throw new Error(`overrides[${index}].pattern must be a non-empty string`);
+  }
+  if (typeof obj.group !== "string" || obj.group.trim() === "") {
+    throw new Error(`overrides[${index}].group must be a non-empty string`);
+  }
+
+  const group = obj.group.trim();
+  if (!validGroups.has(group)) {
+    throw new Error(
+      `overrides[${index}].group "${group}" does not match any defined group`,
+    );
+  }
+
+  return { pattern: obj.pattern.trim(), group };
+}

--- a/graph/src/heuristics.ts
+++ b/graph/src/heuristics.ts
@@ -1,0 +1,246 @@
+import type { GroupDefinition } from "./types.ts";
+
+// ---------------------------------------------------------------------------
+// Semantic tag system
+//
+// Each heuristic rule tags a file with semantic labels. These tags are then
+// matched against keywords extracted from each group's name and description.
+// The group with the most matching tags wins.
+// ---------------------------------------------------------------------------
+
+/**
+ * A built-in rule that assigns semantic tags to a file based on its path.
+ */
+interface HeuristicRule {
+  /** Regex tested against the file path (forward-slash normalised). */
+  test: RegExp;
+  /** Semantic tags produced when the rule matches. */
+  tags: string[];
+}
+
+/**
+ * Built-in heuristic rules. Order does not matter — all matching rules
+ * contribute tags, and the group with the highest aggregate score wins.
+ */
+const RULES: HeuristicRule[] = [
+  // ---- Directory-based rules ----
+  { test: /\/components?\//, tags: ["ui", "component"] },
+  { test: /\/pages?\//, tags: ["ui", "page"] },
+  { test: /\/views?\//, tags: ["ui", "view"] },
+  { test: /\/layouts?\//, tags: ["ui", "layout"] },
+  { test: /\/hooks?\//, tags: ["ui", "hook"] },
+  { test: /\/widgets?\//, tags: ["ui", "widget"] },
+
+  { test: /\/routes?\//, tags: ["api", "route"] },
+  { test: /\/api\//, tags: ["api", "route"] },
+  { test: /\/controllers?\//, tags: ["api", "controller"] },
+  { test: /\/handlers?\//, tags: ["api", "handler"] },
+  { test: /\/middleware\//, tags: ["api", "middleware"] },
+  { test: /\/endpoints?\//, tags: ["api", "endpoint"] },
+
+  { test: /\/models?\//, tags: ["data", "model"] },
+  { test: /\/schemas?\//, tags: ["data", "schema"] },
+  { test: /\/entities?\//, tags: ["data", "entity"] },
+  { test: /\/migrations?\//, tags: ["data", "migration"] },
+  { test: /\/types\//, tags: ["data", "type"] },
+
+  { test: /\/services?\//, tags: ["logic", "service"] },
+  { test: /\/lib\//, tags: ["logic", "lib"] },
+  { test: /\/utils?\//, tags: ["logic", "util"] },
+  { test: /\/helpers?\//, tags: ["logic", "helper"] },
+  { test: /\/core\//, tags: ["logic", "core"] },
+  { test: /\/domain\//, tags: ["logic", "domain"] },
+
+  { test: /\/store\//, tags: ["state", "store"] },
+  { test: /\/state\//, tags: ["state"] },
+  { test: /\/context\//, tags: ["state", "context"] },
+
+  { test: /\/styles?\//, tags: ["style"] },
+  { test: /\/themes?\//, tags: ["style", "theme"] },
+  { test: /\/config\//, tags: ["config"] },
+  { test: /\/constants?\//, tags: ["config", "constant"] },
+
+  // ---- File suffix-based rules ----
+  { test: /\.component\.[tj]sx?$/, tags: ["ui", "component"] },
+  { test: /\.page\.[tj]sx?$/, tags: ["ui", "page"] },
+  { test: /\.route\.[tj]sx?$/, tags: ["api", "route"] },
+  { test: /\.controller\.[tj]sx?$/, tags: ["api", "controller"] },
+  { test: /\.handler\.[tj]sx?$/, tags: ["api", "handler"] },
+  { test: /\.model\.[tj]sx?$/, tags: ["data", "model"] },
+  { test: /\.schema\.[tj]sx?$/, tags: ["data", "schema"] },
+  { test: /\.entity\.[tj]sx?$/, tags: ["data", "entity"] },
+  { test: /\.service\.[tj]sx?$/, tags: ["logic", "service"] },
+  { test: /\.util\.[tj]sx?$/, tags: ["logic", "util"] },
+  { test: /\.helper\.[tj]sx?$/, tags: ["logic", "helper"] },
+  { test: /\.hook\.[tj]sx?$/, tags: ["ui", "hook"] },
+
+  // ---- Extension-based rules (lower signal, still useful) ----
+  { test: /\.[tj]sx$/, tags: ["ui"] },
+  { test: /\.css$/, tags: ["style"] },
+  { test: /\.scss$/, tags: ["style"] },
+];
+
+/**
+ * Maps keywords (from group name/description) to the semantic tags they
+ * correspond to. This bridges the gap between arbitrary user-defined group
+ * names and the fixed tag vocabulary used by heuristic rules.
+ */
+const KEYWORD_TAGS: Record<string, string[]> = {
+  // UI
+  ui: ["ui"],
+  component: ["ui", "component"],
+  components: ["ui", "component"],
+  frontend: ["ui"],
+  react: ["ui", "component"],
+  view: ["ui", "view"],
+  views: ["ui", "view"],
+  page: ["ui", "page"],
+  pages: ["ui", "page"],
+  render: ["ui"],
+  layout: ["ui", "layout"],
+  widget: ["ui", "widget"],
+  hook: ["ui", "hook"],
+
+  // API
+  api: ["api"],
+  route: ["api", "route"],
+  routes: ["api", "route"],
+  endpoint: ["api", "endpoint"],
+  endpoints: ["api", "endpoint"],
+  http: ["api"],
+  handler: ["api", "handler"],
+  handlers: ["api", "handler"],
+  controller: ["api", "controller"],
+  controllers: ["api", "controller"],
+  middleware: ["api", "middleware"],
+  backend: ["api"],
+  server: ["api"],
+
+  // Data
+  data: ["data"],
+  model: ["data", "model"],
+  models: ["data", "model"],
+  database: ["data"],
+  schema: ["data", "schema"],
+  schemas: ["data", "schema"],
+  entity: ["data", "entity"],
+  entities: ["data", "entity"],
+  migration: ["data", "migration"],
+  type: ["data", "type"],
+  types: ["data", "type"],
+
+  // Logic
+  business: ["logic"],
+  logic: ["logic"],
+  service: ["logic", "service"],
+  services: ["logic", "service"],
+  domain: ["logic", "domain"],
+  core: ["logic", "core"],
+  utility: ["logic", "util"],
+  utilities: ["logic", "util"],
+  util: ["logic", "util"],
+  utils: ["logic", "util"],
+  helper: ["logic", "helper"],
+  helpers: ["logic", "helper"],
+  lib: ["logic", "lib"],
+  library: ["logic", "lib"],
+
+  // State
+  state: ["state"],
+  store: ["state", "store"],
+  context: ["state", "context"],
+  redux: ["state", "store"],
+
+  // Style
+  style: ["style"],
+  styles: ["style"],
+  styling: ["style"],
+  css: ["style"],
+  theme: ["style", "theme"],
+
+  // Config
+  config: ["config"],
+  configuration: ["config"],
+  constant: ["config", "constant"],
+  constants: ["config", "constant"],
+  setting: ["config"],
+  settings: ["config"],
+};
+
+/**
+ * Extract semantic tags from a file path by running every built-in rule.
+ */
+export function tagsForFile(filePath: string): Set<string> {
+  // Normalise to forward slashes for consistent matching
+  const normalised = filePath.replace(/\\/g, "/");
+  const tags = new Set<string>();
+
+  for (const rule of RULES) {
+    if (rule.test.test(normalised)) {
+      for (const tag of rule.tags) {
+        tags.add(tag);
+      }
+    }
+  }
+
+  return tags;
+}
+
+/**
+ * Extract semantic tags from a group definition by tokenising its name and
+ * description and looking up each token in the keyword → tag mapping.
+ */
+export function tagsForGroup(group: GroupDefinition): Set<string> {
+  const text = `${group.name} ${group.description}`;
+  const tokens = text.toLowerCase().match(/[a-z]+/g) ?? [];
+  const tags = new Set<string>();
+
+  for (const token of tokens) {
+    const mapped = KEYWORD_TAGS[token];
+    if (mapped) {
+      for (const tag of mapped) {
+        tags.add(tag);
+      }
+    }
+  }
+
+  return tags;
+}
+
+/**
+ * Score how well a file matches a group. Returns the number of overlapping
+ * semantic tags between the file's tags and the group's tags.
+ */
+export function scoreMatch(fileTags: Set<string>, groupTags: Set<string>): number {
+  let score = 0;
+  for (const tag of fileTags) {
+    if (groupTags.has(tag)) {
+      score++;
+    }
+  }
+  return score;
+}
+
+/**
+ * Find the best matching group for a file. Returns the group name and its
+ * score, or null if no group scored above zero.
+ */
+export function bestGroup(
+  filePath: string,
+  groups: GroupDefinition[],
+): { group: string; score: number } | null {
+  const fileTags = tagsForFile(filePath);
+  if (fileTags.size === 0) return null;
+
+  let best: { group: string; score: number } | null = null;
+
+  for (const g of groups) {
+    const groupTags = tagsForGroup(g);
+    const score = scoreMatch(fileTags, groupTags);
+    if (score > 0 && (best === null || score > best.score)) {
+      best = { group: g.name, score };
+    }
+  }
+
+  return best;
+}

--- a/graph/src/index.ts
+++ b/graph/src/index.ts
@@ -1,2 +1,14 @@
 export { extractFileGraph } from "./extract.ts";
-export type { FileEdge } from "./types.ts";
+export { loadGroupConfig, parseGroupConfig } from "./config.ts";
+export { classifyFiles } from "./classify.ts";
+export type { ClassifyOptions } from "./classify.ts";
+export { tagsForFile, tagsForGroup, scoreMatch, bestGroup } from "./heuristics.ts";
+export type {
+  FileEdge,
+  GroupDefinition,
+  GroupOverride,
+  GroupConfig,
+  ClassificationStrategy,
+  FileClassification,
+  ClassificationResult,
+} from "./types.ts";

--- a/graph/src/types.ts
+++ b/graph/src/types.ts
@@ -9,3 +9,67 @@ export interface FileEdge {
   /** Named imports crossing this edge (e.g. ["createUser", "UserSchema"]). */
   symbols: string[];
 }
+
+// ---------------------------------------------------------------------------
+// Phase 2: Group Configuration and Heuristic Classification
+// ---------------------------------------------------------------------------
+
+/**
+ * A user-defined semantic group that source files can be classified into.
+ */
+export interface GroupDefinition {
+  /** Human-readable group name (e.g. "UI Components"). */
+  name: string;
+  /** Describes what belongs in this group. Used by heuristics and LLM. */
+  description: string;
+}
+
+/**
+ * Pins a file glob pattern to a specific group. Overrides take priority
+ * over heuristic classification.
+ */
+export interface GroupOverride {
+  /** Glob pattern matched against the file path relative to the project root. */
+  pattern: string;
+  /** Name of the group to assign. Must reference a defined group. */
+  group: string;
+}
+
+/**
+ * Full group configuration loaded from a YAML file.
+ */
+export interface GroupConfig {
+  groups: GroupDefinition[];
+  overrides?: GroupOverride[];
+}
+
+/**
+ * How a file was assigned to its group.
+ *
+ * - `override`  — matched a user-defined glob override
+ * - `heuristic` — matched a built-in heuristic rule
+ * - `default`   — fell back to the first group (lowest confidence)
+ */
+export type ClassificationStrategy = "override" | "heuristic" | "default";
+
+/**
+ * The classification result for a single source file.
+ */
+export interface FileClassification {
+  /** Absolute path of the classified file. */
+  file: string;
+  /** Name of the assigned group. */
+  group: string;
+  /** How the assignment was determined. */
+  strategy: ClassificationStrategy;
+}
+
+/**
+ * Aggregated classification output for an entire project.
+ */
+export interface ClassificationResult {
+  /** Files that were successfully classified into a group. */
+  classifications: FileClassification[];
+  /** Absolute paths of files that no heuristic could confidently classify. */
+  unclassified: string[];
+}

--- a/graph/test/classify.test.ts
+++ b/graph/test/classify.test.ts
@@ -1,0 +1,329 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { classifyFiles } from "../src/classify.ts";
+import { tagsForFile, tagsForGroup, bestGroup } from "../src/heuristics.ts";
+import type { GroupConfig, GroupDefinition } from "../src/types.ts";
+
+// ---------------------------------------------------------------------------
+// Standard group config used across tests
+// ---------------------------------------------------------------------------
+
+const GROUPS: GroupDefinition[] = [
+  { name: "UI Components", description: "React components that render UI" },
+  { name: "API Routes", description: "HTTP endpoint handlers" },
+  { name: "Data Models", description: "Database schemas and types" },
+  { name: "Business Logic", description: "Core domain services and utilities" },
+];
+
+const CONFIG: GroupConfig = { groups: GROUPS };
+
+// ---------------------------------------------------------------------------
+// Heuristic tag tests
+// ---------------------------------------------------------------------------
+
+describe("tagsForFile", () => {
+  test("tags component directory files", () => {
+    const tags = tagsForFile("/project/src/components/Button.tsx");
+    expect(tags.has("ui")).toBe(true);
+    expect(tags.has("component")).toBe(true);
+  });
+
+  test("tags route directory files", () => {
+    const tags = tagsForFile("/project/src/routes/users.ts");
+    expect(tags.has("api")).toBe(true);
+    expect(tags.has("route")).toBe(true);
+  });
+
+  test("tags model directory files", () => {
+    const tags = tagsForFile("/project/src/models/User.ts");
+    expect(tags.has("data")).toBe(true);
+    expect(tags.has("model")).toBe(true);
+  });
+
+  test("tags service directory files", () => {
+    const tags = tagsForFile("/project/src/services/auth.ts");
+    expect(tags.has("logic")).toBe(true);
+    expect(tags.has("service")).toBe(true);
+  });
+
+  test("tags lib directory files", () => {
+    const tags = tagsForFile("/project/src/lib/crypto.ts");
+    expect(tags.has("logic")).toBe(true);
+    expect(tags.has("lib")).toBe(true);
+  });
+
+  test("tags utils directory files", () => {
+    const tags = tagsForFile("/project/src/utils/format.ts");
+    expect(tags.has("logic")).toBe(true);
+    expect(tags.has("util")).toBe(true);
+  });
+
+  test("tags .tsx files as UI", () => {
+    const tags = tagsForFile("/project/src/App.tsx");
+    expect(tags.has("ui")).toBe(true);
+  });
+
+  test("tags file-suffix conventions", () => {
+    expect(tagsForFile("/project/user.model.ts").has("data")).toBe(true);
+    expect(tagsForFile("/project/user.service.ts").has("logic")).toBe(true);
+    expect(tagsForFile("/project/user.controller.ts").has("api")).toBe(true);
+    expect(tagsForFile("/project/user.schema.ts").has("data")).toBe(true);
+  });
+
+  test("returns empty set for unrecognised paths", () => {
+    const tags = tagsForFile("/project/README.md");
+    expect(tags.size).toBe(0);
+  });
+
+  test("handles Windows-style backslash paths", () => {
+    const tags = tagsForFile("C:\\project\\src\\components\\Button.tsx");
+    expect(tags.has("ui")).toBe(true);
+    expect(tags.has("component")).toBe(true);
+  });
+});
+
+describe("tagsForGroup", () => {
+  test("extracts tags from UI Components group", () => {
+    const tags = tagsForGroup(GROUPS[0]); // "UI Components" / "React components that render UI"
+    expect(tags.has("ui")).toBe(true);
+    expect(tags.has("component")).toBe(true);
+  });
+
+  test("extracts tags from API Routes group", () => {
+    const tags = tagsForGroup(GROUPS[1]); // "API Routes" / "HTTP endpoint handlers"
+    expect(tags.has("api")).toBe(true);
+    expect(tags.has("route")).toBe(true);
+  });
+
+  test("extracts tags from Data Models group", () => {
+    const tags = tagsForGroup(GROUPS[2]); // "Data Models" / "Database schemas and types"
+    expect(tags.has("data")).toBe(true);
+    expect(tags.has("model")).toBe(true);
+  });
+
+  test("extracts tags from Business Logic group", () => {
+    const tags = tagsForGroup(GROUPS[3]); // "Business Logic" / "Core domain services and utilities"
+    expect(tags.has("logic")).toBe(true);
+    expect(tags.has("service")).toBe(true);
+  });
+});
+
+describe("bestGroup", () => {
+  test("classifies component file to UI Components", () => {
+    const result = bestGroup("/src/components/Button.tsx", GROUPS);
+    expect(result).not.toBeNull();
+    expect(result!.group).toBe("UI Components");
+  });
+
+  test("classifies route file to API Routes", () => {
+    const result = bestGroup("/src/routes/users.ts", GROUPS);
+    expect(result).not.toBeNull();
+    expect(result!.group).toBe("API Routes");
+  });
+
+  test("classifies model file to Data Models", () => {
+    const result = bestGroup("/src/models/User.ts", GROUPS);
+    expect(result).not.toBeNull();
+    expect(result!.group).toBe("Data Models");
+  });
+
+  test("classifies service file to Business Logic", () => {
+    const result = bestGroup("/src/services/auth.ts", GROUPS);
+    expect(result).not.toBeNull();
+    expect(result!.group).toBe("Business Logic");
+  });
+
+  test("classifies utils file to Business Logic", () => {
+    const result = bestGroup("/src/utils/format.ts", GROUPS);
+    expect(result).not.toBeNull();
+    expect(result!.group).toBe("Business Logic");
+  });
+
+  test("returns null for unrecognised files", () => {
+    const result = bestGroup("/project/README.md", GROUPS);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyFiles integration tests
+// ---------------------------------------------------------------------------
+
+describe("classifyFiles", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    // Create a temporary project structure
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "classify-test-"));
+
+    const dirs = [
+      "src/components",
+      "src/routes",
+      "src/models",
+      "src/services",
+      "src/lib",
+      "src/utils",
+      "src/config",
+    ];
+    for (const d of dirs) {
+      fs.mkdirSync(path.join(tmpDir, d), { recursive: true });
+    }
+
+    const files: Record<string, string> = {
+      "src/components/Button.tsx": "export function Button() { return <button />; }",
+      "src/components/Header.tsx": "export function Header() { return <header />; }",
+      "src/routes/users.ts": "export function getUsers() {}",
+      "src/routes/health.ts": "export function healthCheck() {}",
+      "src/models/User.ts": "export interface User { id: string; }",
+      "src/models/Order.ts": "export interface Order { id: string; }",
+      "src/services/auth.ts": "export function login() {}",
+      "src/lib/crypto.ts": "export function hash() {}",
+      "src/utils/format.ts": "export function formatDate() {}",
+      "src/config/env.ts": "export const PORT = 3000;",
+      "README.md": "# Project",
+    };
+
+    for (const [filePath, content] of Object.entries(files)) {
+      fs.writeFileSync(path.join(tmpDir, filePath), content);
+    }
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function filePaths(...relative: string[]): string[] {
+    return relative.map((r) => path.join(tmpDir, r));
+  }
+
+  test("classifies files using heuristics", () => {
+    const files = filePaths(
+      "src/components/Button.tsx",
+      "src/routes/users.ts",
+      "src/models/User.ts",
+      "src/services/auth.ts",
+    );
+
+    const result = classifyFiles(files, CONFIG, { projectRoot: tmpDir });
+
+    expect(result.classifications).toHaveLength(4);
+    expect(result.unclassified).toHaveLength(0);
+
+    const byFile = new Map(
+      result.classifications.map((c) => [path.relative(tmpDir, c.file), c]),
+    );
+
+    expect(byFile.get("src/components/Button.tsx")!.group).toBe("UI Components");
+    expect(byFile.get("src/routes/users.ts")!.group).toBe("API Routes");
+    expect(byFile.get("src/models/User.ts")!.group).toBe("Data Models");
+    expect(byFile.get("src/services/auth.ts")!.group).toBe("Business Logic");
+
+    // All should be heuristic-based
+    for (const c of result.classifications) {
+      expect(c.strategy).toBe("heuristic");
+    }
+  });
+
+  test("unrecognised files are unclassified", () => {
+    const files = filePaths("README.md");
+    const result = classifyFiles(files, CONFIG, { projectRoot: tmpDir });
+
+    expect(result.classifications).toHaveLength(0);
+    expect(result.unclassified).toHaveLength(1);
+    expect(result.unclassified[0]).toBe(path.join(tmpDir, "README.md"));
+  });
+
+  test("overrides take priority over heuristics", () => {
+    const configWithOverride: GroupConfig = {
+      ...CONFIG,
+      overrides: [
+        { pattern: "src/components/**", group: "Business Logic" },
+      ],
+    };
+
+    const files = filePaths("src/components/Button.tsx");
+    const result = classifyFiles(files, configWithOverride, {
+      projectRoot: tmpDir,
+    });
+
+    expect(result.classifications).toHaveLength(1);
+    expect(result.classifications[0].group).toBe("Business Logic");
+    expect(result.classifications[0].strategy).toBe("override");
+  });
+
+  test("caching persists and reuses classifications", () => {
+    const cacheDir = path.join(tmpDir, ".cache");
+    const files = filePaths("src/components/Button.tsx");
+
+    // First run — should classify via heuristic
+    const result1 = classifyFiles(files, CONFIG, {
+      projectRoot: tmpDir,
+      cacheDir,
+    });
+    expect(result1.classifications[0].strategy).toBe("heuristic");
+
+    // Second run — should hit cache
+    const result2 = classifyFiles(files, CONFIG, {
+      projectRoot: tmpDir,
+      cacheDir,
+    });
+    expect(result2.classifications[0].group).toBe("UI Components");
+    // Cache returns the stored strategy
+    expect(result2.classifications[0].strategy).toBe("heuristic");
+  });
+
+  test("cache invalidates on file content change", () => {
+    const cacheDir = path.join(tmpDir, ".cache-invalidation");
+    const btnPath = path.join(tmpDir, "src/components/Button.tsx");
+    const files = [btnPath];
+
+    // First run
+    classifyFiles(files, CONFIG, { projectRoot: tmpDir, cacheDir });
+
+    // Modify the file
+    fs.writeFileSync(btnPath, "export function Button() { return <div />; }");
+
+    // Second run — cache should miss because content changed
+    const result = classifyFiles(files, CONFIG, {
+      projectRoot: tmpDir,
+      cacheDir,
+    });
+    expect(result.classifications[0].group).toBe("UI Components");
+    expect(result.classifications[0].strategy).toBe("heuristic");
+
+    // Restore original content
+    fs.writeFileSync(
+      btnPath,
+      "export function Button() { return <button />; }",
+    );
+  });
+
+  test("each file is assigned to exactly one group", () => {
+    const files = filePaths(
+      "src/components/Button.tsx",
+      "src/components/Header.tsx",
+      "src/routes/users.ts",
+      "src/routes/health.ts",
+      "src/models/User.ts",
+      "src/models/Order.ts",
+      "src/services/auth.ts",
+      "src/lib/crypto.ts",
+      "src/utils/format.ts",
+    );
+
+    const result = classifyFiles(files, CONFIG, { projectRoot: tmpDir });
+
+    // Every classified file appears exactly once
+    const classified = result.classifications.map((c) => c.file);
+    const unique = new Set(classified);
+    expect(unique.size).toBe(classified.length);
+
+    // No file is both classified and unclassified
+    const unclassSet = new Set(result.unclassified);
+    for (const c of result.classifications) {
+      expect(unclassSet.has(c.file)).toBe(false);
+    }
+  });
+});

--- a/graph/test/config.test.ts
+++ b/graph/test/config.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect } from "bun:test";
+import { parseGroupConfig } from "../src/config.ts";
+
+describe("parseGroupConfig", () => {
+  test("parses a minimal valid config", () => {
+    const config = parseGroupConfig(`
+groups:
+  - name: "UI Components"
+    description: "React components that render UI"
+`);
+    expect(config.groups).toHaveLength(1);
+    expect(config.groups[0].name).toBe("UI Components");
+    expect(config.groups[0].description).toBe(
+      "React components that render UI",
+    );
+    expect(config.overrides).toBeUndefined();
+  });
+
+  test("parses multiple groups", () => {
+    const config = parseGroupConfig(`
+groups:
+  - name: "UI Components"
+    description: "React components"
+  - name: "API Routes"
+    description: "HTTP endpoint handlers"
+  - name: "Data Models"
+    description: "Database schemas and types"
+  - name: "Business Logic"
+    description: "Core domain services"
+`);
+    expect(config.groups).toHaveLength(4);
+    expect(config.groups.map((g) => g.name)).toEqual([
+      "UI Components",
+      "API Routes",
+      "Data Models",
+      "Business Logic",
+    ]);
+  });
+
+  test("parses overrides", () => {
+    const config = parseGroupConfig(`
+groups:
+  - name: "UI Components"
+    description: "React components"
+  - name: "Business Logic"
+    description: "Core domain services"
+overrides:
+  - pattern: "src/config/**"
+    group: "Business Logic"
+  - pattern: "src/components/legacy/**"
+    group: "UI Components"
+`);
+    expect(config.overrides).toHaveLength(2);
+    expect(config.overrides![0]).toEqual({
+      pattern: "src/config/**",
+      group: "Business Logic",
+    });
+    expect(config.overrides![1]).toEqual({
+      pattern: "src/components/legacy/**",
+      group: "UI Components",
+    });
+  });
+
+  test("trims whitespace from names and descriptions", () => {
+    const config = parseGroupConfig(`
+groups:
+  - name: "  UI Components  "
+    description: "  React components  "
+`);
+    expect(config.groups[0].name).toBe("UI Components");
+    expect(config.groups[0].description).toBe("React components");
+  });
+
+  test("rejects empty input", () => {
+    expect(() => parseGroupConfig("")).toThrow("YAML object");
+  });
+
+  test("rejects config without groups", () => {
+    expect(() => parseGroupConfig("overrides: []")).toThrow(
+      "at least one group",
+    );
+  });
+
+  test("rejects empty groups array", () => {
+    expect(() => parseGroupConfig("groups: []")).toThrow("at least one group");
+  });
+
+  test("rejects group without name", () => {
+    expect(() =>
+      parseGroupConfig(`
+groups:
+  - description: "Some group"
+`),
+    ).toThrow("groups[0].name");
+  });
+
+  test("rejects group without description", () => {
+    expect(() =>
+      parseGroupConfig(`
+groups:
+  - name: "Foo"
+`),
+    ).toThrow("groups[0].description");
+  });
+
+  test("rejects duplicate group names", () => {
+    expect(() =>
+      parseGroupConfig(`
+groups:
+  - name: "Foo"
+    description: "First"
+  - name: "Foo"
+    description: "Second"
+`),
+    ).toThrow('Duplicate group name: "Foo"');
+  });
+
+  test("rejects override referencing non-existent group", () => {
+    expect(() =>
+      parseGroupConfig(`
+groups:
+  - name: "UI"
+    description: "UI stuff"
+overrides:
+  - pattern: "**/*.ts"
+    group: "NonExistent"
+`),
+    ).toThrow('"NonExistent" does not match any defined group');
+  });
+
+  test("rejects override without pattern", () => {
+    expect(() =>
+      parseGroupConfig(`
+groups:
+  - name: "UI"
+    description: "UI stuff"
+overrides:
+  - group: "UI"
+`),
+    ).toThrow("overrides[0].pattern");
+  });
+
+  test("rejects override without group", () => {
+    expect(() =>
+      parseGroupConfig(`
+groups:
+  - name: "UI"
+    description: "UI stuff"
+overrides:
+  - pattern: "**/*.ts"
+`),
+    ).toThrow("overrides[0].group");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "hono": "^4.7.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250121.0",


### PR DESCRIPTION
Implements Phase 2 of the graph extraction plan: group configuration
and heuristic classification. Users declare semantic groups in YAML
and the system automatically classifies source files using directory
structure, naming conventions, and framework patterns.

- YAML group config format with validation (config.ts)
- Tag-based heuristic classifier mapping path patterns to groups (heuristics.ts)
- Classification orchestrator with override/heuristic/cache layers (classify.ts)
- Content-hash caching to avoid re-classifying unchanged files
- Manual glob overrides for user-pinned group assignments

https://claude.ai/code/session_01FjMReuDh3WNpvhNprQKwdT