### PR TITLE
Enable Worker observability logging

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -16,6 +16,12 @@
       "migrations_dir": "worker/migrations"
     }
   ],
+  "observability": {
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true
+    }
+  },
   "queues": {
     "producers": [
       {


### PR DESCRIPTION
## Summary
Enable Worker observability with logs and invocation_logs configuration in wrangler.json for better monitoring and debugging.

## Test plan
- [ ] Deploy to staging and verify logs are captured in Cloudflare dashboard
- [ ] Confirm invocation logs are properly recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)