### PR TITLE
feat: add automated analysis pipeline via GitHub Actions

### DIFF
--- a/.github/workflows/analyze-caller.yml
+++ b/.github/workflows/analyze-caller.yml
@@ -1,0 +1,13 @@
+name: Analyze (Caller)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  analyze:
+    uses: ./.github/workflows/analyze.yml
+    with:
+      repository: ${{ github.repository }}

--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,0 +1,43 @@
+name: Analyze Dependencies
+
+on:
+  workflow_call:
+    inputs:
+      repository:
+        description: "Repository name (owner/repo)"
+        required: true
+        type: string
+
+env:
+  CALLBACK_URL: https://clanki.ruud-andriessen.workers.dev/api/analysis/results
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: Run analysis
+        run: bun graph/src/analyze-for-ci.ts --project-root . > analysis-results.json
+
+      - name: Post results
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ inputs.repository }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          PAYLOAD=$(jq --arg repo "$REPOSITORY" --arg sha "$COMMIT_SHA" \
+            '. + {repository: $repo, commitSha: $sha}' analysis-results.json)
+
+          curl -sf -X POST "${CALLBACK_URL}" \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -d "${PAYLOAD}"

--- a/graph/src/analyze-for-ci.ts
+++ b/graph/src/analyze-for-ci.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+import path from "path";
+import fs from "fs";
+import { extractFileGraph } from "./extract.ts";
+import { loadGroupConfig } from "./config.ts";
+import { classifyFiles } from "./classify.ts";
+import { buildGroupGraph } from "./group-graph.ts";
+
+function parseArgs(args: string[]): { projectRoot: string; groupsConfig?: string } {
+  let projectRoot = process.cwd();
+  let groupsConfig: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--project-root" && args[i + 1]) {
+      projectRoot = path.resolve(args[++i]);
+    } else if (args[i] === "--groups-config" && args[i + 1]) {
+      groupsConfig = path.resolve(args[++i]);
+    }
+  }
+
+  return { projectRoot, groupsConfig };
+}
+
+function findGroupsConfig(projectRoot: string): string | null {
+  for (const name of ["groups.yml", "clanki.yml"]) {
+    const p = path.join(projectRoot, name);
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+function findTsconfigs(projectRoot: string): string[] {
+  const entries = fs.readdirSync(projectRoot);
+  return entries
+    .filter((e) => /^tsconfig(\..+)?\.json$/.test(e))
+    .map((e) => path.join(projectRoot, e));
+}
+
+const { projectRoot, groupsConfig } = parseArgs(process.argv.slice(2));
+
+// Resolve groups config
+const configPath = groupsConfig ?? findGroupsConfig(projectRoot);
+if (!configPath) {
+  console.error("No groups.yml or clanki.yml found in project root. Provide --groups-config.");
+  process.exit(1);
+}
+
+const config = loadGroupConfig(configPath);
+
+// Find and process tsconfigs
+const tsconfigs = findTsconfigs(projectRoot);
+if (tsconfigs.length === 0) {
+  console.error("No tsconfig*.json files found in project root.");
+  process.exit(1);
+}
+
+const allEdges = [];
+for (const tsconfigPath of tsconfigs) {
+  const name = path.basename(tsconfigPath);
+  console.error(`Extracting from ${name}...`);
+  const edges = extractFileGraph(tsconfigPath);
+  console.error(`  ${edges.length} edges`);
+  allEdges.push(...edges);
+}
+
+// Collect all unique file paths
+const allFiles = new Set<string>();
+for (const edge of allEdges) {
+  allFiles.add(edge.from);
+  allFiles.add(edge.to);
+}
+console.error(`${allFiles.size} unique files across all programs`);
+
+// Classify (no caching in CI)
+const classification = classifyFiles([...allFiles], config, { projectRoot });
+
+// Build group graph
+const groupEdges = buildGroupGraph(allEdges, classification);
+
+// Strip absolute paths to relative
+const stripAbs = (p: string) => path.relative(projectRoot, p);
+
+const output = {
+  groups: config.groups,
+  fileEdges: allEdges.map((e) => ({
+    from: stripAbs(e.from),
+    to: stripAbs(e.to),
+    symbols: e.symbols,
+  })),
+  classifications: classification.classifications.map((c) => ({
+    file: stripAbs(c.file),
+    group: c.group,
+    strategy: c.strategy,
+  })),
+  unclassified: classification.unclassified.map(stripAbs),
+  groupEdges,
+};
+
+// Output JSON to stdout (progress logs go to stderr)
+console.log(JSON.stringify(output));

--- a/worker/src/api/snapshot-results.ts
+++ b/worker/src/api/snapshot-results.ts
@@ -1,0 +1,163 @@
+import { eq, and } from "drizzle-orm";
+import type { Context } from "hono";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import * as schema from "../db/schema";
+
+interface AnalysisPayload {
+  repository: string;
+  commitSha: string;
+  fileEdges: Array<{ from: string; to: string; symbols: string[] }>;
+  classifications: Array<{ file: string; group: string; strategy: string }>;
+  groupEdges: Array<{ from: string; to: string; weight: number; symbols: string[] }>;
+  groups: Array<{ name: string; description: string }>;
+}
+
+/**
+ * Verify a GitHub token has access to the claimed repository.
+ * Calls the GitHub API to confirm the token is valid and scoped to this repo.
+ */
+async function verifyGitHubToken(token: string, repository: string): Promise<boolean> {
+  const res = await fetch(`https://api.github.com/repos/${repository}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "User-Agent": "clanki-worker",
+    },
+  });
+  if (!res.ok) return false;
+  const data = (await res.json()) as { full_name?: string };
+  return data.full_name === repository;
+}
+
+/**
+ * Insert rows in batches to stay within D1's parameter limits.
+ */
+async function batchInsert<T extends Record<string, unknown>>(
+  db: DrizzleD1Database<typeof schema>,
+  table: Parameters<typeof db.insert>[0],
+  rows: T[],
+  batchSize = 50,
+): Promise<void> {
+  for (let i = 0; i < rows.length; i += batchSize) {
+    const batch = rows.slice(i, i + batchSize);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (db.insert(table) as any).values(batch);
+  }
+}
+
+export async function handleAnalysisResults(c: Context): Promise<Response> {
+  const db = c.get("db") as DrizzleD1Database<typeof schema>;
+
+  // Parse body
+  let payload: AnalysisPayload;
+  try {
+    payload = await c.req.json<AnalysisPayload>();
+  } catch {
+    return c.json({ error: "invalid JSON body" }, 400);
+  }
+
+  const { repository, commitSha } = payload;
+  if (!repository || !commitSha) {
+    return c.json({ error: "repository and commitSha are required" }, 400);
+  }
+
+  // Verify the GitHub token has access to the claimed repository
+  const authHeader = c.req.header("Authorization");
+  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+  if (!token || !(await verifyGitHubToken(token, repository))) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
+
+  // Find the snapshot by commit SHA + repo
+  const repoUrl = `https://github.com/${repository}`;
+  const project = await db.query.projects.findFirst({
+    where: eq(schema.projects.repoUrl, repoUrl),
+  });
+
+  if (!project) {
+    return c.json({ error: `no project found for repository ${repository}` }, 404);
+  }
+
+  const snapshot = await db.query.snapshots.findFirst({
+    where: and(
+      eq(schema.snapshots.projectId, project.id),
+      eq(schema.snapshots.commitSha, commitSha),
+    ),
+  });
+
+  if (!snapshot) {
+    return c.json({ error: `no snapshot found for commit ${commitSha}` }, 404);
+  }
+
+  if (snapshot.status === "complete") {
+    return c.json({ message: "snapshot already complete" }, 200);
+  }
+
+  // Insert file edges
+  if (payload.fileEdges.length > 0) {
+    const rows = payload.fileEdges.map((e) => ({
+      id: crypto.randomUUID(),
+      snapshotId: snapshot.id,
+      fromFile: e.from,
+      toFile: e.to,
+      symbols: JSON.stringify(e.symbols),
+    }));
+    await batchInsert(db, schema.fileEdges, rows);
+  }
+
+  // Insert classifications
+  if (payload.classifications.length > 0) {
+    const rows = payload.classifications.map((c) => ({
+      id: crypto.randomUUID(),
+      snapshotId: snapshot.id,
+      filePath: c.file,
+      groupName: c.group,
+      strategy: c.strategy,
+    }));
+    await batchInsert(db, schema.fileClassifications, rows);
+  }
+
+  // Insert group edges
+  if (payload.groupEdges.length > 0) {
+    const rows = payload.groupEdges.map((e) => ({
+      id: crypto.randomUUID(),
+      snapshotId: snapshot.id,
+      fromGroup: e.from,
+      toGroup: e.to,
+      weight: e.weight,
+      symbols: JSON.stringify(e.symbols),
+    }));
+    await batchInsert(db, schema.groupEdges, rows);
+  }
+
+  // Upsert group definitions
+  for (const group of payload.groups) {
+    const existing = await db.query.groupDefinitions.findFirst({
+      where: and(
+        eq(schema.groupDefinitions.projectId, project.id),
+        eq(schema.groupDefinitions.name, group.name),
+      ),
+    });
+    if (existing) {
+      await db
+        .update(schema.groupDefinitions)
+        .set({ description: group.description })
+        .where(eq(schema.groupDefinitions.id, existing.id));
+    } else {
+      await db.insert(schema.groupDefinitions).values({
+        id: crypto.randomUUID(),
+        projectId: project.id,
+        name: group.name,
+        description: group.description,
+      });
+    }
+  }
+
+  // Mark snapshot complete
+  await db
+    .update(schema.snapshots)
+    .set({ status: "complete" })
+    .where(eq(schema.snapshots.id, snapshot.id));
+
+  return c.json({ message: "ok", snapshotId: snapshot.id }, 200);
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -6,6 +6,7 @@ import { createAuth } from "./auth";
 import type { QueueMessage } from "./queue/message";
 import { processQueueMessage } from "./queue/processMessage";
 import { handleGitHubWebhook } from "./webhook/github";
+import { handleAnalysisResults } from "./api/snapshot-results";
 
 type Bindings = {
   ASSETS: Fetcher;
@@ -54,6 +55,8 @@ app.on(["POST", "GET"], "/api/auth/*", (c) => {
 app.get("/api/health", (c) => {
   return c.json({ status: "ok" });
 });
+
+app.post("/api/analysis/results", (c) => handleAnalysisResults(c));
 
 app.post("/webhook", (c) => handleGitHubWebhook(c));
 


### PR DESCRIPTION
## Summary

Add GitHub Actions workflows to automatically run graph analysis when PRs merge. The workflow triggers on push to main, extracts the dependency graph, and posts results to a new worker API endpoint for storage.

## Changes

- **CI analysis runner** (`graph/src/analyze-for-ci.ts`) — Auto-detects tsconfigs and outputs JSON to stdout
- **Results API** (`POST /api/analysis/results`) — Stores analysis results in D1, matched by repo + commit SHA
- **GitHub Actions workflows** — Reusable workflow runs analysis, caller workflow triggers on push to main
- **HMAC authentication** — Verifies workflow requests before storing results
- **Batch insertion** — Respects D1 limits by batching file edges, classifications, and group edges

## Next steps

1. Set secrets: `wrangler secret put ANALYSIS_CALLBACK_SECRET`
2. Set repo secret: `ANALYSIS_CALLBACK_SECRET` (same value)
3. Set repo variable: `ANALYSIS_CALLBACK_URL=https://clanki.ruud-andriessen.workers.dev/api/analysis/results`
4. Merge PR and test with a new commit to main