### PR TITLE
refactor: replace || with ?? for default values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,21 @@ Examples:
 - `feat: add user login flow`
 - `fix(worker): handle empty request body`
 - `docs: update README with deploy steps`
+
+## Code Style
+
+### Prefer `??` over `||` for default values
+
+Use the nullish coalescing operator (`??`) instead of logical OR (`||`) when providing fallback/default values. `??` only falls back on `null`/`undefined`, while `||` also falls back on `0`, `""`, and `false` — which are often valid values.
+
+```ts
+// Good — only falls back when value is null/undefined
+const color = colors[name] ?? "#default";
+const count = counts[key] ?? 0;
+
+// Bad — would also fall back on 0, "", or false
+const color = colors[name] || "#default";
+const count = counts[key] || 0;
+```
+
+Keep `||` for boolean logic (e.g., `a > 0 || b > 0`) and sort tiebreakers (e.g., `a.localeCompare(b) || a.x.localeCompare(b.x)`).

--- a/frontend/src/components/graph-view.tsx
+++ b/frontend/src/components/graph-view.tsx
@@ -23,7 +23,7 @@ export function GraphView({ data }: { data: GraphData }) {
   const fileCounts = useMemo(() => {
     const counts: Record<string, number> = {};
     for (const c of data.classifications) {
-      counts[c.group] = (counts[c.group] || 0) + 1;
+      counts[c.group] = (counts[c.group] ?? 0) + 1;
     }
     return counts;
   }, [data]);
@@ -45,8 +45,8 @@ export function GraphView({ data }: { data: GraphData }) {
         },
         data: {
           label: g.name,
-          fileCount: fileCounts[g.name] || 0,
-          color: GROUP_COLORS[g.name] || DEFAULT_COLOR,
+          fileCount: fileCounts[g.name] ?? 0,
+          color: GROUP_COLORS[g.name] ?? DEFAULT_COLOR,
           description: g.description,
         },
         style: { background: "transparent", padding: 0, border: "none", boxShadow: "none" },
@@ -66,12 +66,12 @@ export function GraphView({ data }: { data: GraphData }) {
         labelBgPadding: [8, 4] as [number, number],
         labelBgBorderRadius: 4,
         style: {
-          stroke: GROUP_COLORS[e.from] || DEFAULT_COLOR,
+          stroke: GROUP_COLORS[e.from] ?? DEFAULT_COLOR,
           strokeWidth: Math.max(1.5, Math.min(e.weight, 6)),
         },
         markerEnd: {
           type: MarkerType.ArrowClosed,
-          color: GROUP_COLORS[e.from] || DEFAULT_COLOR,
+          color: GROUP_COLORS[e.from] ?? DEFAULT_COLOR,
         },
         animated: true,
       })),

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -244,7 +244,7 @@ function Sidebar({ onClose }: { onClose: () => void }) {
                 <span
                   className="w-2.5 h-2.5 rounded-full shrink-0"
                   style={{
-                    backgroundColor: GROUP_COLORS[g.name] || "#6b7280",
+                    backgroundColor: GROUP_COLORS[g.name] ?? "#6b7280",
                   }}
                 />
                 {g.name}

--- a/frontend/src/pages/group-page.tsx
+++ b/frontend/src/pages/group-page.tsx
@@ -28,7 +28,7 @@ export function GroupDetailPage() {
         fileEdgesIn: [],
       };
 
-    const group = data.groups.find((g) => g.name === name) || null;
+    const group = data.groups.find((g) => g.name === name) ?? null;
     const files = data.classifications.filter((c) => c.group === name);
     const outgoing = data.groupEdges.filter((e) => e.from === name);
     const incoming = data.groupEdges.filter((e) => e.to === name);
@@ -60,7 +60,7 @@ export function GroupDetailPage() {
     );
   }
 
-  const color = GROUP_COLORS[name] || "#6b7280";
+  const color = GROUP_COLORS[name] ?? "#6b7280";
 
   return (
     <div className="h-full overflow-y-auto">
@@ -113,7 +113,7 @@ export function GroupDetailPage() {
                       to="/group/$name"
                       params={{ name: e.to }}
                       className="font-medium text-sm hover:underline"
-                      style={{ color: GROUP_COLORS[e.to] || "#6b7280" }}
+                      style={{ color: GROUP_COLORS[e.to] ?? "#6b7280" }}
                     >
                       {e.to}
                     </Link>
@@ -150,7 +150,7 @@ export function GroupDetailPage() {
                       to="/group/$name"
                       params={{ name: e.from }}
                       className="font-medium text-sm hover:underline"
-                      style={{ color: GROUP_COLORS[e.from] || "#6b7280" }}
+                      style={{ color: GROUP_COLORS[e.from] ?? "#6b7280" }}
                     >
                       {e.from}
                     </Link>


### PR DESCRIPTION
Use nullish coalescing (??) instead of logical OR (||) for fallback values where the lookup returns undefined on miss. This prevents unintended fallbacks on valid falsy values like 0 or "".

Also adds a code style guideline to CLAUDE.md to prefer ?? over || for default values going forward.

https://claude.ai/code/session_015andAsMwNfmtZu6q8oKini