### PR TITLE
Add clanki.ai custom domain

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -22,6 +22,12 @@
       "invocation_logs": true
     }
   },
+  "routes": [
+    {
+      "pattern": "clanki.ai",
+      "custom_domain": true
+    }
+  ],
   "queues": {
     "producers": [
       {


### PR DESCRIPTION
Configure clanki.ai as a custom domain in the Cloudflare Worker configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)