### PR TITLE
fix(ci): improve curl error visibility in analysis results POST

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -34,10 +34,10 @@ jobs:
           REPOSITORY: ${{ inputs.repository }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          PAYLOAD=$(jq --arg repo "$REPOSITORY" --arg sha "$COMMIT_SHA" \
-            '. + {repository: $repo, commitSha: $sha}' analysis-results.json)
+          jq --arg repo "$REPOSITORY" --arg sha "$COMMIT_SHA" \
+            '. + {repository: $repo, commitSha: $sha}' analysis-results.json > payload.json
 
-          curl -sf -X POST "${CALLBACK_URL}" \
+          curl -sS --fail-with-body -X POST "${CALLBACK_URL}" \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -d "${PAYLOAD}"
+            -d @payload.json


### PR DESCRIPTION
Exit code 22 from curl indicates an HTTP error, but the previous silent flags (-sf) prevented the error response from being displayed.

This fix uses --fail-with-body to show the actual server error message (401, 404, etc.) in the workflow logs. Also writes the jq payload to a file instead of a shell variable to avoid expansion issues with large or special-character results.

🤖 Generated with Claude Code