### PR TITLE
feat: migrate to clanki.ai custom domain

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 env:
-  CALLBACK_URL: https://clanki.ruud-andriessen.workers.dev/api/analysis/results
+  CALLBACK_URL: https://clanki.ai/api/analysis/results
 
 jobs:
   analyze:

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -6,7 +6,7 @@ import { eq, and } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/d1";
 import * as schema from "./db/schema";
 
-const PRODUCTION_URL = "https://clanki.ruud-andriessen.workers.dev";
+const PRODUCTION_URL = "https://clanki.ai";
 
 type AuthEnv = {
   DB: D1Database;


### PR DESCRIPTION
Replace all references to the temporary workers.dev domain with the custom clanki.ai domain for auth callbacks and analysis results.

## Changes
- Updated GitHub Actions workflow callback URL
- Updated auth production URL for OAuth redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)