### PR TITLE
fix(worker): respect D1's 100 bind-parameter limit in batch inserts

### DIFF
--- a/worker/src/api/snapshot-results.ts
+++ b/worker/src/api/snapshot-results.ts
@@ -31,14 +31,16 @@ async function verifyGitHubToken(token: string, repository: string): Promise<boo
 }
 
 /**
- * Insert rows in batches to stay within D1's parameter limits.
+ * Insert rows in batches to stay within D1's 100 bind-parameter limit.
  */
 async function batchInsert<T extends Record<string, unknown>>(
   db: DrizzleD1Database<typeof schema>,
   table: Parameters<typeof db.insert>[0],
   rows: T[],
-  batchSize = 50,
 ): Promise<void> {
+  if (rows.length === 0) return;
+  const columnsPerRow = Object.keys(rows[0]).length;
+  const batchSize = Math.max(1, Math.floor(100 / columnsPerRow));
   for (let i = 0; i < rows.length; i += batchSize) {
     const batch = rows.slice(i, i + batchSize);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary
- Fixed D1 query failures when inserting large batches of file edges
- The hardcoded batch size of 50 rows was causing 250 bind parameters per query, exceeding D1's 100-parameter limit
- Now batch size is calculated dynamically based on column count to stay within limits

## Details
This resolves the internal server error (500) on POST /api/analysis/results that occurs when analysis runs. The batchInsert function now computes the appropriate batch size for each table based on its column count, ensuring no query exceeds D1's bind parameter constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)