### PR TITLE
Move organization rename control from sidebar to breadcrumb header

### DIFF
--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { Outlet, Link, useRouterState, useNavigate } from "@tanstack/react-router";
-import { Menu, X, LogOut, Loader2, Building2, Pencil, Check, Settings } from "lucide-react";
+import { Menu, X, LogOut, Loader2, Settings } from "lucide-react";
 import { cn } from "../lib/utils";
 import { useSession, signOut, authClient } from "../lib/auth-client";
 
@@ -16,80 +16,6 @@ function useOrganization() {
   }, [activeOrg.isPending, activeOrg.data, orgs.data]);
 
   return activeOrg;
-}
-
-function OrgSwitcher() {
-  const activeOrg = useOrganization();
-  const [editing, setEditing] = useState(false);
-  const [name, setName] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (editing && inputRef.current) {
-      inputRef.current.focus();
-      inputRef.current.select();
-    }
-  }, [editing]);
-
-  const org = activeOrg.data;
-  if (!org) return null;
-
-  const handleSave = async () => {
-    const trimmed = name.trim();
-    if (trimmed && trimmed !== org.name) {
-      await authClient.organization.update({
-        data: { name: trimmed },
-        organizationId: org.id,
-      });
-    }
-    setEditing(false);
-  };
-
-  if (editing) {
-    return (
-      <div className="px-3 py-3 border-b border-border">
-        <div className="flex items-center gap-1.5">
-          <Building2 className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
-          <input
-            ref={inputRef}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleSave();
-              if (e.key === "Escape") setEditing(false);
-            }}
-            onBlur={handleSave}
-            className="flex-1 min-w-0 px-2 py-1 rounded-md text-sm bg-background border border-border text-foreground outline-none focus:ring-1 focus:ring-primary"
-          />
-          <button
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={handleSave}
-            className="p-1 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors shrink-0"
-          >
-            <Check className="w-3.5 h-3.5" />
-          </button>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="px-3 py-3 border-b border-border">
-      <button
-        type="button"
-        onClick={() => {
-          setName(org.name);
-          setEditing(true);
-        }}
-        className="w-full flex items-center gap-2 px-2.5 py-1.5 rounded-md text-sm text-foreground hover:bg-accent transition-colors group"
-      >
-        <Building2 className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
-        <span className="truncate font-medium">{org.name}</span>
-        <Pencil className="w-3 h-3 text-muted-foreground ml-auto shrink-0 md:opacity-0 md:group-hover:opacity-100 transition-opacity" />
-      </button>
-    </div>
-  );
 }
 
 function UserProfile() {
@@ -167,9 +93,6 @@ function Sidebar({ onClose, children }: { onClose: () => void; children?: React.
           <X className="w-5 h-5" />
         </button>
       </div>
-
-      <OrgSwitcher />
-
       {children}
 
       <div className="flex-1" />

--- a/frontend/src/components/project-layout.tsx
+++ b/frontend/src/components/project-layout.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { Outlet, Link, useParams, useNavigate } from "@tanstack/react-router";
 import { useLiveQuery } from "@tanstack/react-db";
-import { LayoutDashboard, GitBranch, Loader2, ChevronDown } from "lucide-react";
+import { LayoutDashboard, GitBranch, Loader2, ChevronDown, Pencil, Check } from "lucide-react";
 import {
   projectsCollection,
   getSnapshotsCollection,
@@ -25,7 +25,33 @@ export function ProjectLayout() {
 
   // Get org name for breadcrumb
   const activeOrg = authClient.useActiveOrganization();
-  const orgName = activeOrg.data?.name;
+  const org = activeOrg.data;
+  const [editingOrgName, setEditingOrgName] = useState(false);
+  const [orgName, setOrgName] = useState("");
+  const orgInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!editingOrgName || !orgInputRef.current) return;
+    orgInputRef.current.focus();
+    orgInputRef.current.select();
+  }, [editingOrgName]);
+
+  async function handleSaveOrgName() {
+    if (!org) {
+      setEditingOrgName(false);
+      return;
+    }
+
+    const trimmed = orgName.trim();
+    if (trimmed && trimmed !== org.name) {
+      await authClient.organization.update({
+        data: { name: trimmed },
+        organizationId: org.id,
+      });
+    }
+
+    setEditingOrgName(false);
+  }
 
   // Get all projects for repo dropdown
   const { data: projects } = useLiveQuery((q) => q.from({ p: projectsCollection }));
@@ -160,9 +186,41 @@ export function ProjectLayout() {
         {/* Breadcrumb header */}
         <div className="px-4 py-2 border-b border-border flex items-center gap-1.5 shrink-0 min-h-[41px]">
           {/* Org name */}
-          <span className="text-sm text-muted-foreground truncate">
-            {orgName ?? "Organization"}
-          </span>
+          {editingOrgName ? (
+            <div className="flex items-center gap-1">
+              <input
+                ref={orgInputRef}
+                value={orgName}
+                onChange={(e) => setOrgName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleSaveOrgName();
+                  if (e.key === "Escape") setEditingOrgName(false);
+                }}
+                onBlur={handleSaveOrgName}
+                className="min-w-24 max-w-48 px-2 py-0.5 rounded-md text-sm bg-background border border-border text-foreground outline-none focus:ring-1 focus:ring-primary"
+              />
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={handleSaveOrgName}
+                className="p-1 rounded-md text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+              >
+                <Check className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                setOrgName(org?.name ?? "");
+                setEditingOrgName(true);
+              }}
+              className="group flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors max-w-52"
+            >
+              <span className="truncate">{org?.name ?? "Organization"}</span>
+              <Pencil className="w-3 h-3 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </button>
+          )}
 
           <span className="text-muted-foreground text-xs">/</span>
 


### PR DESCRIPTION
### Motivation
- Simplify the sidebar by relocating the organization rename affordance into the page-level breadcrumb so the organization name is more visible while browsing projects. 
- Keep the existing inline rename UX (edit-in-place, save on Enter/blur/click, cancel on Escape) but surface it where project context is shown. 

### Description
- Removed the `OrgSwitcher` editable block and related icon imports from `frontend/src/components/layout.tsx` and no longer render the org rename in the left sidebar. 
- Added inline editing state, input focus handling, and save logic to the breadcrumb header in `frontend/src/components/project-layout.tsx`, including `editingOrgName`, `orgName` state, `orgInputRef`, and `handleSaveOrgName`. 
- Continued to call `authClient.organization.update` with the active org id when the name changes so backend behavior is preserved. 

### Testing
- Built the frontend with `bun run build:frontend` which completed successfully. 
- Launched the dev frontend with `bun run dev:frontend` and captured a screenshot of the updated UI for verification. 
- The dev server started and the screenshot artifact was produced at `browser:/tmp/codex_browser_invocations/f1307ff2ec16d4a6/artifacts/artifacts/org-rename-breadcrumb.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b0edbff348321b7ae7f53c2d9109e)