### PR TITLE
fix(frontend): move sidebar user avatar menu to footer

### DIFF
--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -216,9 +216,6 @@ function Sidebar({ onClose, children }: { onClose: () => void; children?: React.
           </Link>
           <p className="text-xs text-muted-foreground mt-1">Architecture Explorer</p>
         </div>
-        <div className="hidden md:block shrink-0">
-          <UserMenu />
-        </div>
         <button
           className="md:hidden p-1 rounded-md hover:bg-accent text-muted-foreground"
           onClick={onClose}
@@ -232,6 +229,10 @@ function Sidebar({ onClose, children }: { onClose: () => void; children?: React.
       {children}
 
       <div className="flex-1" />
+
+      <div className="hidden md:block p-3 border-t border-border">
+        <UserMenu />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Align the desktop sidebar with the shadcn-style layout by moving the user avatar/menu to the bottom of the sidebar while keeping mobile behavior unchanged.

### Description
- Removed the `UserMenu` from the sidebar header and added a bottom footer block that renders `UserMenu` in `frontend/src/components/layout.tsx` so the avatar/menu appears at the bottom on desktop.

### Testing
- Ran `bun run format` and `bun run lint:fix` (both succeeded) and validated the UI by starting the frontend with `bun run dev:frontend --host 0.0.0.0` and capturing a screenshot via Playwright (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b509f3c4c832198b0b2b05e72ebc9)