### PR TITLE
fix: keep dev login local and use remote D1

### DIFF
--- a/frontend/src/pages/login-page.tsx
+++ b/frontend/src/pages/login-page.tsx
@@ -23,7 +23,12 @@ export function LoginPage() {
 
         <button
           type="button"
-          onClick={() => signIn.social({ provider: "github", callbackURL: "/" })}
+          onClick={() =>
+            signIn.social({
+              provider: "github",
+              callbackURL: new URL("/", window.location.origin).toString(),
+            })
+          }
           className="flex w-full items-center justify-center gap-2 rounded-md border border-border bg-card px-4 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-accent"
         >
           <Github className="h-4 w-4" />

--- a/wrangler.json
+++ b/wrangler.json
@@ -12,7 +12,7 @@
       "binding": "DB",
       "database_name": "clanki-db",
       "database_id": "202e7e1a-b025-4cc3-977e-e7dfa7ef794c",
-      "remote": false,
+      "remote": true,
       "migrations_dir": "worker/migrations"
     }
   ],


### PR DESCRIPTION
## Summary
- make local GitHub sign-in use an absolute callback URL derived from the current origin
- set Wrangler D1 binding to remote by default for dev

## Validation
- bun run format
- bun run lint:fix
- bun run build