### PR TITLE
fix(frontend): prevent mobile chat UI zoom and send button clipping

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, interactive-widget=resizes-content"
+    />
     <title>Clanki</title>
   </head>
   <body>

--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -353,7 +353,7 @@ export function Layout() {
 
   if (isPending) {
     return (
-      <div className="flex h-screen items-center justify-center bg-background">
+      <div className="flex h-dvh items-center justify-center bg-background">
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
       </div>
     );
@@ -362,7 +362,7 @@ export function Layout() {
   if (!session) return null;
 
   return (
-    <div className="flex h-screen bg-background text-foreground">
+    <div className="flex h-dvh bg-background text-foreground">
       {/* Mobile backdrop */}
       <div
         className={cn(

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,13 @@
   --color-accent-foreground: #ededed;
 }
 
+html,
+body,
+#root {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   font-family:
     system-ui,

--- a/frontend/src/pages/task-page.tsx
+++ b/frontend/src/pages/task-page.tsx
@@ -115,7 +115,7 @@ export function TaskPage() {
             onKeyDown={handleKeyDown}
             placeholder="Send a message..."
             rows={1}
-            className="flex-1 resize-none rounded-lg border border-border bg-background px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground outline-none focus:ring-1 focus:ring-primary min-h-[42px] max-h-[200px]"
+            className="flex-1 resize-none rounded-lg border border-border bg-background px-4 py-2.5 text-base md:text-sm text-foreground placeholder:text-muted-foreground outline-none focus:ring-1 focus:ring-primary min-h-[42px] max-h-[200px]"
             style={{ height: "auto" }}
             onInput={(e) => {
               const target = e.target as HTMLTextAreaElement;


### PR DESCRIPTION
- Add maximum-scale=1.0 and interactive-widget=resizes-content to
  viewport meta to prevent auto-zoom on input focus and resize layout
  when virtual keyboard appears
- Switch h-screen (100vh) to h-dvh (100dvh) so the layout respects
  mobile browser chrome and virtual keyboard height
- Lock html/body/#root to full height with overflow hidden to prevent
  any outer document scroll
- Use text-base (16px) on mobile for the chat textarea to avoid iOS
  auto-zoom on focus, dropping to text-sm on desktop

https://claude.ai/code/session_01JXCboHFeqrwkMtPfYbS9Ks