### PR TITLE
feat: add OpenCode provider OAuth and credential management

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,7 +3,7 @@ const BASE = "/api";
 async function fetchJson<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE}${path}`, { credentials: "include" });
   if (!res.ok) {
-    throw new Error(`API ${res.status}: ${path}`);
+    throw new Error(await toApiErrorMessage(res, path));
   }
   return res.json();
 }
@@ -16,7 +16,20 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
     body: JSON.stringify(body),
   });
   if (!res.ok) {
-    throw new Error(`API ${res.status}: ${path}`);
+    throw new Error(await toApiErrorMessage(res, path));
+  }
+  return res.json();
+}
+
+async function putJson<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    method: "PUT",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(await toApiErrorMessage(res, path));
   }
   return res.json();
 }
@@ -29,7 +42,7 @@ async function patchJson<T>(path: string, body: unknown): Promise<T> {
     body: JSON.stringify(body),
   });
   if (!res.ok) {
-    throw new Error(`API ${res.status}: ${path}`);
+    throw new Error(await toApiErrorMessage(res, path));
   }
   return res.json();
 }
@@ -40,8 +53,20 @@ async function deleteJson(path: string): Promise<void> {
     credentials: "include",
   });
   if (!res.ok) {
-    throw new Error(`API ${res.status}: ${path}`);
+    throw new Error(await toApiErrorMessage(res, path));
   }
+}
+
+async function toApiErrorMessage(res: Response, path: string): Promise<string> {
+  try {
+    const payload = (await res.json()) as { error?: unknown; message?: unknown };
+    const error = payload.error ?? payload.message;
+    if (typeof error === "string" && error.trim().length > 0) {
+      return error;
+    }
+  } catch {}
+
+  return `API ${res.status}: ${path}`;
 }
 
 // ---- Types matching API responses ----
@@ -121,6 +146,9 @@ export interface TaskRun {
   outputMessageId: string | null;
   sandboxId: string | null;
   sessionId: string | null;
+  initiatedByUserId: string | null;
+  provider: string;
+  model: string;
   error: string | null;
   startedAt: number | null;
   finishedAt: number | null;
@@ -162,8 +190,22 @@ export function createTaskMessage(taskId: string, role: string, content: string)
   return postJson<TaskMessage>(`/tasks/${taskId}/messages`, { role, content });
 }
 
-export function createTaskRun(taskId: string, messageId?: string) {
-  return postJson<TaskRun>(`/tasks/${taskId}/runs`, messageId ? { messageId } : {});
+export function createTaskRun(
+  taskId: string,
+  messageId?: string,
+  options?: { provider?: string; model?: string },
+) {
+  const body: { messageId?: string; provider?: string; model?: string } = {};
+  if (messageId) {
+    body.messageId = messageId;
+  }
+  if (options?.provider) {
+    body.provider = options.provider;
+  }
+  if (options?.model) {
+    body.model = options.model;
+  }
+  return postJson<TaskRun>(`/tasks/${taskId}/runs`, body);
 }
 
 export function fetchTaskRun(runId: string) {
@@ -173,4 +215,45 @@ export function fetchTaskRun(runId: string) {
 export function fetchTaskRunEvents(runId: string, after?: number) {
   const query = after !== undefined ? `?after=${after}` : "";
   return fetchJson<TaskRunEvent[]>(`/tasks/runs/${runId}/events${query}`);
+}
+
+// ---- Provider settings ----
+
+export interface ProviderCredentialStatus {
+  provider: string;
+  configured: boolean;
+  authType: "api" | "oauth" | "wellknown" | null;
+  updatedAt: number | null;
+}
+
+export function fetchProviderCredentialStatus(provider: string) {
+  return fetchJson<ProviderCredentialStatus>(`/settings/providers/${provider}`);
+}
+
+export function upsertProviderCredential(provider: string, apiKey: string) {
+  return putJson<ProviderCredentialStatus>(`/settings/providers/${provider}`, { apiKey });
+}
+
+export function deleteProviderCredential(provider: string) {
+  return deleteJson(`/settings/providers/${provider}`);
+}
+
+export interface ProviderOauthStart {
+  attemptId: string;
+  url: string;
+  instructions: string;
+  method: "auto" | "code";
+  expiresAt: number;
+}
+
+export function startProviderOauth(provider: string) {
+  return postJson<ProviderOauthStart>(`/settings/providers/${provider}/oauth/start`, {});
+}
+
+export function completeProviderOauth(provider: string, attemptId: string, code?: string) {
+  const body: { attemptId: string; code?: string } = { attemptId };
+  if (code?.trim()) {
+    body.code = code.trim();
+  }
+  return postJson<ProviderCredentialStatus>(`/settings/providers/${provider}/oauth/complete`, body);
 }

--- a/frontend/src/pages/settings-page.tsx
+++ b/frontend/src/pages/settings-page.tsx
@@ -1,17 +1,132 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLiveQuery } from "@tanstack/react-db";
 import { BookMarked, Loader2, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  completeProviderOauth,
+  deleteProviderCredential,
+  fetchProviderCredentialStatus,
+  startProviderOauth,
+  upsertProviderCredential,
+  type ProviderCredentialStatus,
+  type ProviderOauthStart,
+} from "../lib/api";
 import { AddProjectDialog } from "../components/add-project-dialog";
 import { projectsCollection, queryClient } from "../lib/collections";
+
+const OPENAI_PROVIDER = "openai";
 
 export function SettingsPage() {
   const { data: projects, isLoading } = useLiveQuery((q) => q.from({ p: projectsCollection }));
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [openaiApiKey, setOpenaiApiKey] = useState("");
+  const [openaiStatus, setOpenaiStatus] = useState<ProviderCredentialStatus | null>(null);
+  const [loadingStatus, setLoadingStatus] = useState(true);
+  const [savingKey, setSavingKey] = useState(false);
+  const [removingKey, setRemovingKey] = useState(false);
+  const [startingOauth, setStartingOauth] = useState(false);
+  const [completingOauth, setCompletingOauth] = useState(false);
+  const [oauthAttempt, setOauthAttempt] = useState<ProviderOauthStart | null>(null);
+  const [providerError, setProviderError] = useState<string | null>(null);
 
   function handleCreated() {
     queryClient.invalidateQueries({ queryKey: ["projects"] });
+  }
+
+  useEffect(() => {
+    void loadOpenAiStatus();
+  }, []);
+
+  async function loadOpenAiStatus() {
+    setLoadingStatus(true);
+    setProviderError(null);
+    try {
+      const status = await fetchProviderCredentialStatus(OPENAI_PROVIDER);
+      setOpenaiStatus(status);
+    } catch (error) {
+      setProviderError(error instanceof Error ? error.message : "Failed to load OpenAI settings");
+    } finally {
+      setLoadingStatus(false);
+    }
+  }
+
+  async function handleSaveOpenAiKey() {
+    const apiKey = openaiApiKey.trim();
+    if (apiKey.length === 0 || savingKey) {
+      return;
+    }
+
+    setSavingKey(true);
+    setProviderError(null);
+    try {
+      const status = await upsertProviderCredential(OPENAI_PROVIDER, apiKey);
+      setOpenaiStatus(status);
+      setOpenaiApiKey("");
+    } catch (error) {
+      setProviderError(error instanceof Error ? error.message : "Failed to save OpenAI key");
+    } finally {
+      setSavingKey(false);
+    }
+  }
+
+  async function handleDeleteOpenAiKey() {
+    if (!openaiStatus?.configured || removingKey) {
+      return;
+    }
+
+    setRemovingKey(true);
+    setProviderError(null);
+    try {
+      await deleteProviderCredential(OPENAI_PROVIDER);
+      setOpenaiStatus({
+        provider: OPENAI_PROVIDER,
+        configured: false,
+        authType: null,
+        updatedAt: null,
+      });
+      setOauthAttempt(null);
+    } catch (error) {
+      setProviderError(error instanceof Error ? error.message : "Failed to remove OpenAI key");
+    } finally {
+      setRemovingKey(false);
+    }
+  }
+
+  async function handleStartOauth() {
+    if (startingOauth) {
+      return;
+    }
+
+    setStartingOauth(true);
+    setProviderError(null);
+    try {
+      const attempt = await startProviderOauth(OPENAI_PROVIDER);
+      setOauthAttempt(attempt);
+      window.open(attempt.url, "_blank", "noopener,noreferrer");
+    } catch (error) {
+      setProviderError(error instanceof Error ? error.message : "Failed to start OAuth flow");
+    } finally {
+      setStartingOauth(false);
+    }
+  }
+
+  async function handleCompleteOauth() {
+    if (!oauthAttempt || completingOauth) {
+      return;
+    }
+
+    setCompletingOauth(true);
+    setProviderError(null);
+    try {
+      const status = await completeProviderOauth(OPENAI_PROVIDER, oauthAttempt.attemptId);
+      setOpenaiStatus(status);
+      setOauthAttempt(null);
+    } catch (error) {
+      setProviderError(error instanceof Error ? error.message : "OAuth flow is not complete yet");
+    } finally {
+      setCompletingOauth(false);
+    }
   }
 
   return (
@@ -19,6 +134,100 @@ export function SettingsPage() {
       <h2 className="mb-6 text-lg font-semibold">Settings</h2>
 
       <div className="space-y-6">
+        <section>
+          <h3 className="mb-4 text-sm font-medium tracking-wider text-muted-foreground uppercase">
+            AI Providers
+          </h3>
+
+          <div className="space-y-3 rounded-lg border border-border p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium">OpenAI (Codex)</p>
+                {loadingStatus ? (
+                  <p className="text-xs text-muted-foreground">Loading configuration...</p>
+                ) : openaiStatus?.configured ? (
+                  <p className="text-xs text-muted-foreground">
+                    Configured
+                    {openaiStatus.authType === "oauth" ? " via ChatGPT Plus/Pro" : " via API key"}
+                    {openaiStatus.updatedAt !== null
+                      ? ` · Updated ${new Date(openaiStatus.updatedAt).toLocaleString()}`
+                      : ""}
+                  </p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">No credentials configured</p>
+                )}
+              </div>
+              {loadingStatus ? (
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-2 md:flex-row">
+              <input
+                type="password"
+                value={openaiApiKey}
+                onChange={(e) => setOpenaiApiKey(e.target.value)}
+                placeholder="sk-..."
+                className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-primary"
+              />
+              <Button
+                type="button"
+                onClick={() => void handleSaveOpenAiKey()}
+                disabled={savingKey || openaiApiKey.trim().length === 0}
+              >
+                {savingKey ? "Saving..." : "Save key"}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void handleDeleteOpenAiKey()}
+                disabled={removingKey || !openaiStatus?.configured}
+              >
+                {removingKey ? "Removing..." : "Remove key"}
+              </Button>
+            </div>
+
+            <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
+              <p className="text-xs text-muted-foreground">
+                Prefer ChatGPT Plus/Pro instead of an API key? Use the OAuth flow below.
+              </p>
+              <div className="flex flex-col gap-2 md:flex-row">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => void handleStartOauth()}
+                  disabled={startingOauth}
+                >
+                  {startingOauth ? "Starting..." : "Connect ChatGPT Plus/Pro"}
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => void handleCompleteOauth()}
+                  disabled={!oauthAttempt || completingOauth}
+                >
+                  {completingOauth ? "Checking..." : "I completed sign-in"}
+                </Button>
+              </div>
+
+              {oauthAttempt ? (
+                <div className="space-y-1 text-xs text-muted-foreground">
+                  <p>{oauthAttempt.instructions}</p>
+                  <a
+                    href={oauthAttempt.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="underline underline-offset-2"
+                  >
+                    Open sign-in page
+                  </a>
+                </div>
+              ) : null}
+            </div>
+
+            {providerError ? <p className="text-xs text-destructive">{providerError}</p> : null}
+          </div>
+        </section>
+
         <section>
           <div className="mb-4 flex items-center justify-between">
             <h3 className="text-sm font-medium tracking-wider text-muted-foreground uppercase">

--- a/frontend/src/pages/task-page.tsx
+++ b/frontend/src/pages/task-page.tsx
@@ -58,6 +58,7 @@ export function TaskPage() {
         return a.id.localeCompare(b.id);
       })
     : messages;
+  const hasRunFeedback = activeRunId !== null || runStatus !== null || runError !== null;
 
   useEffect(() => {
     return () => {
@@ -323,12 +324,15 @@ export function TaskPage() {
               </div>
             ))}
 
-            {activeRunId ? (
+            {hasRunFeedback ? (
               <Card className="gap-0 border-border bg-muted/50 py-0">
                 <CardContent className="space-y-1 px-3 py-2">
                   <p className="text-xs font-medium text-foreground">
-                    OpenCode run: {runStatus ?? "queued"}
+                    OpenCode run: {runStatus ?? (runError ? "failed" : "queued")}
                   </p>
+                  {activeRunId ? (
+                    <p className="text-xs text-muted-foreground">run: {activeRunId}</p>
+                  ) : null}
                   {runSandboxId ? (
                     <p className="text-xs text-muted-foreground">sandbox: {runSandboxId}</p>
                   ) : null}

--- a/worker/migrations/0008_green_doomsday.sql
+++ b/worker/migrations/0008_green_doomsday.sql
@@ -1,0 +1,20 @@
+ALTER TABLE `task_runs` ADD `initiated_by_user_id` text REFERENCES `user`(`id`) ON DELETE set null;
+--> statement-breakpoint
+ALTER TABLE `task_runs` ADD `provider` text NOT NULL DEFAULT 'openai';
+--> statement-breakpoint
+ALTER TABLE `task_runs` ADD `model` text NOT NULL DEFAULT 'gpt-5.3-codex';
+--> statement-breakpoint
+CREATE INDEX `task_run_user` ON `task_runs` (`initiated_by_user_id`,`created_at`);
+--> statement-breakpoint
+CREATE TABLE `user_provider_credentials` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`provider` text NOT NULL,
+	`encrypted_api_key` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_provider_unique` ON `user_provider_credentials` (`user_id`,`provider`);--> statement-breakpoint
+CREATE INDEX `user_provider_user` ON `user_provider_credentials` (`user_id`);

--- a/worker/migrations/0009_breezy_polaris.sql
+++ b/worker/migrations/0009_breezy_polaris.sql
@@ -1,0 +1,20 @@
+ALTER TABLE `user_provider_credentials` ADD `auth_type` text NOT NULL DEFAULT 'api';
+--> statement-breakpoint
+ALTER TABLE `user_provider_credentials` ADD `encrypted_auth_json` text;
+--> statement-breakpoint
+CREATE TABLE `user_provider_oauth_attempts` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`provider` text NOT NULL,
+	`sandbox_id` text NOT NULL,
+	`method` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`expires_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_provider_oauth_unique` ON `user_provider_oauth_attempts` (`user_id`,`provider`);
+--> statement-breakpoint
+CREATE INDEX `user_provider_oauth_user` ON `user_provider_oauth_attempts` (`user_id`,`created_at`);
+--> statement-breakpoint
+CREATE INDEX `user_provider_oauth_exp` ON `user_provider_oauth_attempts` (`expires_at`);

--- a/worker/migrations/meta/0008_snapshot.json
+++ b/worker/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1837 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c2701d5e-6cbe-4331-9a69-8f124aed02f4",
+  "prevId": "de41b34d-fb66-45d1-a78f-67d97cbc0384",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_classifications": {
+      "name": "file_classifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "strategy": {
+          "name": "strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "classification_snapshot_file": {
+          "name": "classification_snapshot_file",
+          "columns": [
+            "snapshot_id",
+            "file_path"
+          ],
+          "isUnique": true
+        },
+        "classification_snapshot_group": {
+          "name": "classification_snapshot_group",
+          "columns": [
+            "snapshot_id",
+            "group_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "file_classifications_snapshot_id_snapshots_id_fk": {
+          "name": "file_classifications_snapshot_id_snapshots_id_fk",
+          "tableFrom": "file_classifications",
+          "tableTo": "snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_edges": {
+      "name": "file_edges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_file": {
+          "name": "from_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_file": {
+          "name": "to_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbols": {
+          "name": "symbols",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "file_edge_unique": {
+          "name": "file_edge_unique",
+          "columns": [
+            "snapshot_id",
+            "from_file",
+            "to_file"
+          ],
+          "isUnique": true
+        },
+        "file_edge_from": {
+          "name": "file_edge_from",
+          "columns": [
+            "snapshot_id",
+            "from_file"
+          ],
+          "isUnique": false
+        },
+        "file_edge_to": {
+          "name": "file_edge_to",
+          "columns": [
+            "snapshot_id",
+            "to_file"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "file_edges_snapshot_id_snapshots_id_fk": {
+          "name": "file_edges_snapshot_id_snapshots_id_fk",
+          "tableFrom": "file_edges",
+          "tableTo": "snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_definitions": {
+      "name": "group_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "group_def_project_name": {
+          "name": "group_def_project_name",
+          "columns": [
+            "project_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "group_definitions_project_id_projects_id_fk": {
+          "name": "group_definitions_project_id_projects_id_fk",
+          "tableFrom": "group_definitions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_edges": {
+      "name": "group_edges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_group": {
+          "name": "from_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_group": {
+          "name": "to_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "symbols": {
+          "name": "symbols",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        }
+      },
+      "indexes": {
+        "group_edge_unique": {
+          "name": "group_edge_unique",
+          "columns": [
+            "snapshot_id",
+            "from_group",
+            "to_group"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "group_edges_snapshot_id_snapshots_id_fk": {
+          "name": "group_edges_snapshot_id_snapshots_id_fk",
+          "tableFrom": "group_edges",
+          "tableTo": "snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "group_overrides": {
+      "name": "group_overrides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_name": {
+          "name": "group_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "group_overrides_project_id_projects_id_fk": {
+          "name": "group_overrides_project_id_projects_id_fk",
+          "tableFrom": "group_overrides",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "installations": {
+      "name": "installations",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inviterId": {
+          "name": "inviterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organizationId_organization_id_fk": {
+          "name": "invitation_organizationId_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviterId_user_id_fk": {
+          "name": "invitation_inviterId_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviterId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "member_organizationId_organization_id_fk": {
+          "name": "member_organizationId_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_userId_user_id_fk": {
+          "name": "member_userId_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "narratives": {
+      "name": "narratives",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_id": {
+          "name": "snapshot_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "narrative_snapshot_kind": {
+          "name": "narrative_snapshot_kind",
+          "columns": [
+            "snapshot_id",
+            "kind"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "narratives_snapshot_id_snapshots_id_fk": {
+          "name": "narratives_snapshot_id_snapshots_id_fk",
+          "tableFrom": "narratives",
+          "tableTo": "snapshots",
+          "columnsFrom": [
+            "snapshot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_url": {
+          "name": "repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "projects_installation_id_installations_installation_id_fk": {
+          "name": "projects_installation_id_installations_installation_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "installation_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository": {
+          "name": "repository",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "opened_at": {
+          "name": "opened_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "merged_by": {
+          "name": "merged_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merged_at": {
+          "name": "merged_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ready_at": {
+          "name": "ready_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pr_repo_number": {
+          "name": "pr_repo_number",
+          "columns": [
+            "repository",
+            "pr_number"
+          ],
+          "isUnique": true
+        },
+        "pr_installation": {
+          "name": "pr_installation",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_installation_id_installations_installation_id_fk": {
+          "name": "pull_requests_installation_id_installations_installation_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "installation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "activeOrganizationId": {
+          "name": "activeOrganizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "snapshots": {
+      "name": "snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "branch": {
+          "name": "branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "snapshot_project_created": {
+          "name": "snapshot_project_created",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "snapshots_project_id_projects_id_fk": {
+          "name": "snapshots_project_id_projects_id_fk",
+          "tableFrom": "snapshots",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "snapshots_pull_request_id_pull_requests_id_fk": {
+          "name": "snapshots_pull_request_id_pull_requests_id_fk",
+          "tableFrom": "snapshots",
+          "tableTo": "pull_requests",
+          "columnsFrom": [
+            "pull_request_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_messages": {
+      "name": "task_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "task_message_task": {
+          "name": "task_message_task",
+          "columns": [
+            "task_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "task_messages_task_id_tasks_id_fk": {
+          "name": "task_messages_task_id_tasks_id_fk",
+          "tableFrom": "task_messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_run_events": {
+      "name": "task_run_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "task_run_event_run": {
+          "name": "task_run_event_run",
+          "columns": [
+            "run_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "task_run_events_run_id_task_runs_id_fk": {
+          "name": "task_run_events_run_id_task_runs_id_fk",
+          "tableFrom": "task_run_events",
+          "tableTo": "task_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "task_runs": {
+      "name": "task_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool": {
+          "name": "tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'opencode'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "input_message_id": {
+          "name": "input_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_message_id": {
+          "name": "output_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'openai'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gpt-5.3-codex'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "task_run_task": {
+          "name": "task_run_task",
+          "columns": [
+            "task_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "task_run_status": {
+          "name": "task_run_status",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "task_run_user": {
+          "name": "task_run_user",
+          "columns": [
+            "initiated_by_user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "task_runs_task_id_tasks_id_fk": {
+          "name": "task_runs_task_id_tasks_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_runs_input_message_id_task_messages_id_fk": {
+          "name": "task_runs_input_message_id_task_messages_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "task_messages",
+          "columnsFrom": [
+            "input_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_runs_output_message_id_task_messages_id_fk": {
+          "name": "task_runs_output_message_id_task_messages_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "task_messages",
+          "columnsFrom": [
+            "output_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_runs_initiated_by_user_id_user_id_fk": {
+          "name": "task_runs_initiated_by_user_id_user_id_fk",
+          "tableFrom": "task_runs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "task_org": {
+          "name": "task_org",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_organization_id_organization_id_fk": {
+          "name": "tasks_organization_id_organization_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_provider_credentials": {
+      "name": "user_provider_credentials",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_api_key": {
+          "name": "encrypted_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_provider_unique": {
+          "name": "user_provider_unique",
+          "columns": [
+            "user_id",
+            "provider"
+          ],
+          "isUnique": true
+        },
+        "user_provider_user": {
+          "name": "user_provider_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_provider_credentials_user_id_user_id_fk": {
+          "name": "user_provider_credentials_user_id_user_id_fk",
+          "tableFrom": "user_provider_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/worker/migrations/meta/_journal.json
+++ b/worker/migrations/meta/_journal.json
@@ -57,6 +57,20 @@
       "when": 1771113600000,
       "tag": "0007_task_runs",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1771200000000,
+      "tag": "0008_green_doomsday",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1771286400000,
+      "tag": "0009_breezy_polaris",
+      "breakpoints": true
     }
   ]
 }

--- a/worker/src/db/schema.ts
+++ b/worker/src/db/schema.ts
@@ -56,6 +56,54 @@ export const verification = sqliteTable("verification", {
 });
 
 // ---------------------------------------------------------------------------
+// User provider credentials
+// ---------------------------------------------------------------------------
+
+export const userProviderCredentials = sqliteTable(
+  "user_provider_credentials",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull(),
+    encryptedApiKey: text("encrypted_api_key").notNull(),
+    authType: text("auth_type").notNull().default("api"),
+    encryptedAuthJson: text("encrypted_auth_json"),
+    createdAt: integer("created_at").notNull(),
+    updatedAt: integer("updated_at").notNull(),
+  },
+  (t) => [
+    uniqueIndex("user_provider_unique").on(t.userId, t.provider),
+    index("user_provider_user").on(t.userId),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// User provider OAuth attempts
+// ---------------------------------------------------------------------------
+
+export const userProviderOauthAttempts = sqliteTable(
+  "user_provider_oauth_attempts",
+  {
+    id: text("id").primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull(),
+    sandboxId: text("sandbox_id").notNull(),
+    method: integer("method").notNull(),
+    createdAt: integer("created_at").notNull(),
+    expiresAt: integer("expires_at").notNull(),
+  },
+  (t) => [
+    uniqueIndex("user_provider_oauth_unique").on(t.userId, t.provider),
+    index("user_provider_oauth_user").on(t.userId, t.createdAt),
+    index("user_provider_oauth_exp").on(t.expiresAt),
+  ],
+);
+
+// ---------------------------------------------------------------------------
 // Organizations (BetterAuth)
 // ---------------------------------------------------------------------------
 
@@ -340,6 +388,11 @@ export const taskRuns = sqliteTable(
     }),
     sandboxId: text("sandbox_id"),
     sessionId: text("session_id"),
+    initiatedByUserId: text("initiated_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    provider: text("provider").notNull().default("openai"),
+    model: text("model").notNull().default("gpt-5.3-codex"),
     error: text("error"),
     startedAt: integer("started_at"),
     finishedAt: integer("finished_at"),
@@ -349,6 +402,7 @@ export const taskRuns = sqliteTable(
   (t) => [
     index("task_run_task").on(t.taskId, t.createdAt),
     index("task_run_status").on(t.status, t.createdAt),
+    index("task_run_user").on(t.initiatedByUserId, t.createdAt),
   ],
 );
 

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -7,6 +7,7 @@ import { createAuth } from "./auth";
 import { requireAuth } from "./middleware/requireAuth";
 import { installations } from "./routes/installations";
 import { projects } from "./routes/projects";
+import { settings } from "./routes/settings";
 import { snapshots } from "./routes/snapshots";
 import { tasks } from "./routes/tasks";
 import { handleGitHubWebhook } from "./webhook/github";
@@ -19,6 +20,7 @@ type Bindings = {
   GITHUB_CLIENT_ID: string;
   GITHUB_CLIENT_SECRET: string;
   GITHUB_WEBHOOK_SECRET: string;
+  CREDENTIALS_ENCRYPTION_KEY: string;
   Sandbox: DurableObjectNamespace<Sandbox>;
   GITHUB_APP_ID?: string;
   GITHUB_APP_PRIVATE_KEY?: string;
@@ -69,12 +71,14 @@ app.use("/api/installations/*", requireAuth);
 app.use("/api/projects/*", requireAuth);
 app.use("/api/tasks/*", requireAuth);
 app.use("/api/tasks", requireAuth);
+app.use("/api/settings/*", requireAuth);
 
 // Data API routes
 app.route("/api/installations", installations);
 app.route("/api/projects", projects);
 app.route("/api/projects/:projectId/snapshots", snapshots);
 app.route("/api/tasks", tasks);
+app.route("/api/settings", settings);
 
 app.post("/webhook", (c) => handleGitHubWebhook(c));
 

--- a/worker/src/lib/opencode-auth.ts
+++ b/worker/src/lib/opencode-auth.ts
@@ -1,0 +1,178 @@
+import type { Auth } from "@opencode-ai/sdk";
+import type { Sandbox } from "@cloudflare/sandbox";
+import { OPENCODE_AUTH_FILE_FALLBACK_PATHS } from "./opencode";
+
+export type ProviderAuthSandboxInspection = {
+  provider: string;
+  paths: Array<{
+    path: string;
+    exists: boolean;
+    parseError: boolean;
+    keys: string[];
+    matchedProvider: boolean;
+    hasUniqueAuthCandidate: boolean;
+  }>;
+};
+
+export async function readProviderAuthFromSandbox(
+  sandbox: Sandbox,
+  provider: string,
+): Promise<Auth | null> {
+  const providerId = provider.trim().toLowerCase();
+  let singleAuthCandidate: Auth | null = null;
+
+  for (const authPath of OPENCODE_AUTH_FILE_FALLBACK_PATHS) {
+    const exists = await sandbox.exists(authPath);
+    if (!exists.exists) {
+      continue;
+    }
+
+    const authFile = await sandbox.readFile(authPath);
+    const parsed = parseJsonRecord(authFile.content);
+
+    const exactMatch = findProviderAuth(parsed, providerId);
+    if (exactMatch) {
+      return exactMatch;
+    }
+
+    const uniqueMatch = findUniqueAuth(parsed);
+    if (uniqueMatch && !singleAuthCandidate) {
+      singleAuthCandidate = uniqueMatch;
+    }
+  }
+
+  return singleAuthCandidate;
+}
+
+export async function inspectProviderAuthFromSandbox(
+  sandbox: Sandbox,
+  provider: string,
+): Promise<ProviderAuthSandboxInspection> {
+  const providerId = provider.trim().toLowerCase();
+  const paths: ProviderAuthSandboxInspection["paths"] = [];
+
+  for (const authPath of OPENCODE_AUTH_FILE_FALLBACK_PATHS) {
+    const exists = await sandbox.exists(authPath);
+    if (!exists.exists) {
+      paths.push({
+        path: authPath,
+        exists: false,
+        parseError: false,
+        keys: [],
+        matchedProvider: false,
+        hasUniqueAuthCandidate: false,
+      });
+      continue;
+    }
+
+    const authFile = await sandbox.readFile(authPath);
+    const parsed = parseJsonRecordDetailed(authFile.content);
+    const matchedProvider = findProviderAuth(parsed.record, providerId) !== null;
+    const hasUniqueAuthCandidate = findUniqueAuth(parsed.record) !== null;
+
+    paths.push({
+      path: authPath,
+      exists: true,
+      parseError: parsed.parseError,
+      keys: Object.keys(parsed.record),
+      matchedProvider,
+      hasUniqueAuthCandidate,
+    });
+  }
+
+  return {
+    provider: providerId,
+    paths,
+  };
+}
+
+function parseJsonRecord(value: string): Record<string, unknown> {
+  return parseJsonRecordDetailed(value).record;
+}
+
+function parseJsonRecordDetailed(value: string): {
+  record: Record<string, unknown>;
+  parseError: boolean;
+} {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return { record: {}, parseError: true };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { record: {}, parseError: false };
+  }
+
+  return { record: parsed as Record<string, unknown>, parseError: false };
+}
+
+function findProviderAuth(record: Record<string, unknown>, providerId: string): Auth | null {
+  const exact = record[providerId];
+  if (isAuth(exact)) {
+    return exact;
+  }
+
+  for (const [key, value] of Object.entries(record)) {
+    const normalizedKey = key.trim().toLowerCase();
+    if (
+      normalizedKey === providerId ||
+      normalizedKey.startsWith(`${providerId}:`) ||
+      normalizedKey.endsWith(`:${providerId}`) ||
+      normalizedKey.startsWith(`${providerId}/`) ||
+      normalizedKey.endsWith(`/${providerId}`)
+    ) {
+      if (isAuth(value)) {
+        return value;
+      }
+    }
+  }
+
+  return null;
+}
+
+function findUniqueAuth(record: Record<string, unknown>): Auth | null {
+  let auth: Auth | null = null;
+
+  for (const value of Object.values(record)) {
+    if (!isAuth(value)) {
+      continue;
+    }
+
+    if (auth) {
+      return null;
+    }
+    auth = value;
+  }
+
+  return auth;
+}
+
+function isAuth(value: unknown): value is Auth {
+  if (!value || typeof value !== "object" || Array.isArray(value) || !("type" in value)) {
+    return false;
+  }
+
+  const type = (value as { type?: unknown }).type;
+  if (type === "api") {
+    return typeof (value as { key?: unknown }).key === "string";
+  }
+
+  if (type === "oauth") {
+    return (
+      typeof (value as { access?: unknown }).access === "string" &&
+      typeof (value as { refresh?: unknown }).refresh === "string" &&
+      typeof (value as { expires?: unknown }).expires === "number"
+    );
+  }
+
+  if (type === "wellknown") {
+    return (
+      typeof (value as { key?: unknown }).key === "string" &&
+      typeof (value as { token?: unknown }).token === "string"
+    );
+  }
+
+  return false;
+}

--- a/worker/src/lib/opencode.ts
+++ b/worker/src/lib/opencode.ts
@@ -1,0 +1,56 @@
+export const DEFAULT_OPENCODE_PROVIDER = "openai";
+export const DEFAULT_OPENCODE_MODEL = "gpt-5.3-codex";
+const OPENCODE_AUTH_FILE_PATH = "/home/user/.local/share/opencode/auth.json";
+export const OPENCODE_AUTH_FILE_FALLBACK_PATHS = [
+  OPENCODE_AUTH_FILE_PATH,
+  "/root/.local/share/opencode/auth.json",
+  "/home/sandbox/.local/share/opencode/auth.json",
+] as const;
+export const PROVIDER_OAUTH_ATTEMPT_TTL_MS = 15 * 60 * 1000;
+
+export const SUPPORTED_OPENCODE_PROVIDERS = [DEFAULT_OPENCODE_PROVIDER] as const;
+
+export type SupportedOpencodeProvider = (typeof SUPPORTED_OPENCODE_PROVIDERS)[number];
+
+export function isSupportedOpencodeProvider(value: string): value is SupportedOpencodeProvider {
+  return SUPPORTED_OPENCODE_PROVIDERS.includes(value as SupportedOpencodeProvider);
+}
+
+export function toProviderModelRef(provider: string, model: string): string {
+  return `${provider}/${model}`;
+}
+
+export function buildTaskRunSandboxId(args: {
+  taskId: string;
+  userId: string;
+  provider: string;
+  model: string;
+}): string {
+  return buildBoundedSandboxId("task-run", [args.taskId, args.userId, args.provider, args.model]);
+}
+
+export function buildProviderAuthSandboxId(args: { userId: string; provider: string }): string {
+  return buildBoundedSandboxId("provider-auth", [args.userId, args.provider]);
+}
+
+function buildBoundedSandboxId(prefix: string, parts: string[]): string {
+  const raw = [prefix, ...parts].join(":");
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  const hash = toFnv1aHex(raw);
+  const maxSlugLength = 63 - hash.length - 1;
+  const trimmedSlug = slug.slice(0, Math.max(1, maxSlugLength)).replace(/-+$/g, "");
+  return `${trimmedSlug || "sandbox"}-${hash}`;
+}
+
+function toFnv1aHex(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}

--- a/worker/src/lib/provider-credentials.ts
+++ b/worker/src/lib/provider-credentials.ts
@@ -1,0 +1,210 @@
+import type { Auth } from "@opencode-ai/sdk";
+import { and, eq } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import * as schema from "../db/schema";
+import type { SupportedOpencodeProvider } from "./opencode";
+import { decryptSecret, encryptSecret, type SecretCryptoEnv } from "./secret-crypto";
+
+type ProviderAuthType = Auth["type"];
+type ProviderCredentialStatus = {
+  provider: string;
+  configured: boolean;
+  authType: ProviderAuthType | null;
+  updatedAt: number | null;
+};
+
+export async function getProviderCredentialStatus(
+  db: DrizzleD1Database<typeof schema>,
+  userId: string,
+  provider: SupportedOpencodeProvider,
+): Promise<ProviderCredentialStatus> {
+  const row = await db.query.userProviderCredentials.findFirst({
+    where: and(
+      eq(schema.userProviderCredentials.userId, userId),
+      eq(schema.userProviderCredentials.provider, provider),
+    ),
+    columns: {
+      authType: true,
+      updatedAt: true,
+    },
+  });
+
+  return {
+    provider,
+    configured: Boolean(row),
+    authType: row?.authType ? toAuthType(row.authType) : null,
+    updatedAt: row?.updatedAt ?? null,
+  };
+}
+
+export async function upsertProviderApiKeyCredential(
+  db: DrizzleD1Database<typeof schema>,
+  env: SecretCryptoEnv,
+  userId: string,
+  provider: SupportedOpencodeProvider,
+  apiKey: string,
+): Promise<ProviderCredentialStatus> {
+  const auth: Auth = { type: "api", key: apiKey };
+  return upsertProviderCredential(db, env, userId, provider, auth, apiKey);
+}
+
+export async function upsertProviderAuthCredential(
+  db: DrizzleD1Database<typeof schema>,
+  env: SecretCryptoEnv,
+  userId: string,
+  provider: SupportedOpencodeProvider,
+  auth: Auth,
+): Promise<ProviderCredentialStatus> {
+  const apiKeyValue = auth.type === "api" ? auth.key : "";
+  return upsertProviderCredential(db, env, userId, provider, auth, apiKeyValue);
+}
+
+export async function deleteProviderCredential(
+  db: DrizzleD1Database<typeof schema>,
+  userId: string,
+  provider: SupportedOpencodeProvider,
+): Promise<void> {
+  await db
+    .delete(schema.userProviderCredentials)
+    .where(
+      and(
+        eq(schema.userProviderCredentials.userId, userId),
+        eq(schema.userProviderCredentials.provider, provider),
+      ),
+    );
+}
+
+export async function getDecryptedProviderAuth(
+  db: DrizzleD1Database<typeof schema>,
+  env: SecretCryptoEnv,
+  userId: string,
+  provider: SupportedOpencodeProvider,
+): Promise<Auth | null> {
+  const row = await db.query.userProviderCredentials.findFirst({
+    where: and(
+      eq(schema.userProviderCredentials.userId, userId),
+      eq(schema.userProviderCredentials.provider, provider),
+    ),
+    columns: {
+      authType: true,
+      encryptedApiKey: true,
+      encryptedAuthJson: true,
+    },
+  });
+
+  if (!row) {
+    return null;
+  }
+
+  const authFromJson = await decryptAuthJson(row.encryptedAuthJson, env);
+  if (authFromJson) {
+    return authFromJson;
+  }
+
+  // Backward compatibility for rows created before encrypted_auth_json existed.
+  const apiKey = await decryptSecret(env, row.encryptedApiKey);
+  if (apiKey.trim().length === 0) {
+    return null;
+  }
+
+  return { type: "api", key: apiKey };
+}
+
+async function upsertProviderCredential(
+  db: DrizzleD1Database<typeof schema>,
+  env: SecretCryptoEnv,
+  userId: string,
+  provider: SupportedOpencodeProvider,
+  auth: Auth,
+  encryptedApiKeyValue: string,
+): Promise<ProviderCredentialStatus> {
+  const encryptedApiKey = await encryptSecret(env, encryptedApiKeyValue);
+  const encryptedAuthJson = await encryptSecret(env, JSON.stringify(auth));
+  const authType = auth.type;
+  const now = Date.now();
+  const existing = await db.query.userProviderCredentials.findFirst({
+    where: and(
+      eq(schema.userProviderCredentials.userId, userId),
+      eq(schema.userProviderCredentials.provider, provider),
+    ),
+    columns: { id: true },
+  });
+
+  if (existing) {
+    await db
+      .update(schema.userProviderCredentials)
+      .set({
+        authType,
+        encryptedApiKey,
+        encryptedAuthJson,
+        updatedAt: now,
+      })
+      .where(eq(schema.userProviderCredentials.id, existing.id));
+  } else {
+    await db.insert(schema.userProviderCredentials).values({
+      id: crypto.randomUUID(),
+      userId,
+      provider,
+      authType,
+      encryptedApiKey,
+      encryptedAuthJson,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  return {
+    provider,
+    configured: true,
+    authType,
+    updatedAt: now,
+  };
+}
+
+async function decryptAuthJson(
+  encryptedAuthJson: string | null,
+  env: SecretCryptoEnv,
+): Promise<Auth | null> {
+  if (!encryptedAuthJson) {
+    return null;
+  }
+
+  try {
+    const json = await decryptSecret(env, encryptedAuthJson);
+    const parsed = JSON.parse(json) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || !("type" in parsed)) {
+      return null;
+    }
+
+    const type = (parsed as { type?: unknown }).type;
+    if (type === "api" && typeof (parsed as { key?: unknown }).key === "string") {
+      return parsed as Auth;
+    }
+
+    if (
+      type === "oauth" &&
+      typeof (parsed as { access?: unknown }).access === "string" &&
+      typeof (parsed as { refresh?: unknown }).refresh === "string" &&
+      typeof (parsed as { expires?: unknown }).expires === "number"
+    ) {
+      return parsed as Auth;
+    }
+
+    if (
+      type === "wellknown" &&
+      typeof (parsed as { key?: unknown }).key === "string" &&
+      typeof (parsed as { token?: unknown }).token === "string"
+    ) {
+      return parsed as Auth;
+    }
+  } catch {}
+
+  return null;
+}
+
+function toAuthType(value: string): ProviderAuthType | null {
+  if (value === "api" || value === "oauth" || value === "wellknown") {
+    return value;
+  }
+  return null;
+}

--- a/worker/src/lib/sandbox.ts
+++ b/worker/src/lib/sandbox.ts
@@ -1,23 +1,46 @@
 import { getSandbox } from "@cloudflare/sandbox";
 import { createOpencode } from "@cloudflare/sandbox/opencode";
 import type { Sandbox } from "@cloudflare/sandbox";
-import type { OpencodeClient } from "@opencode-ai/sdk";
+import type { Config, OpencodeClient } from "@opencode-ai/sdk";
 
 const SANDBOX_SLEEP_AFTER = "15m";
+const OPENCODE_COMMAND = "opencode serve --port 4096 --hostname 0.0.0.0";
 
 export type SandboxEnv = {
   Sandbox: DurableObjectNamespace<Sandbox>;
 };
 
-/** Get or resume a sandbox for a given task. Uses taskId as sandbox ID for reuse. */
-export function getTaskSandbox(env: SandboxEnv, taskId: string) {
-  return getSandbox(env.Sandbox, taskId, {
+/** Get or resume a sandbox for a given scope key. */
+export function getTaskSandbox(env: SandboxEnv, sandboxId: string) {
+  return getSandbox(env.Sandbox, sandboxId, {
     sleepAfter: SANDBOX_SLEEP_AFTER,
     normalizeId: true,
   });
 }
 
 /** Start (or connect to) the OpenCode server inside the sandbox and return a typed client. */
-export async function getOpenCodeClient(sandbox: Sandbox, directory: string) {
-  return createOpencode<OpencodeClient>(sandbox, { directory });
+export async function getOpenCodeClient(
+  sandbox: Sandbox,
+  directory: string,
+  config?: Config,
+  options?: { restartServer?: boolean },
+) {
+  const restartServer = options?.restartServer ?? true;
+  if (restartServer) {
+    await restartOpenCodeServer(sandbox);
+  }
+  return createOpencode<OpencodeClient>(sandbox, { directory, config });
+}
+
+async function restartOpenCodeServer(sandbox: Sandbox): Promise<void> {
+  const processes = await sandbox.listProcesses();
+  for (const process of processes) {
+    if (!process.command.includes(OPENCODE_COMMAND)) {
+      continue;
+    }
+
+    try {
+      await process.kill("SIGTERM");
+    } catch {}
+  }
 }

--- a/worker/src/lib/secret-crypto.ts
+++ b/worker/src/lib/secret-crypto.ts
@@ -1,0 +1,76 @@
+const ENCRYPTED_VALUE_VERSION = "v1";
+const AES_GCM_IV_BYTES = 12;
+const AES_256_KEY_BYTES = 32;
+
+export type SecretCryptoEnv = {
+  CREDENTIALS_ENCRYPTION_KEY: string;
+};
+
+let cachedKey: CryptoKey | null = null;
+let cachedRawKey: string | null = null;
+
+export async function encryptSecret(env: SecretCryptoEnv, plaintext: string): Promise<string> {
+  const key = await getCryptoKey(env);
+  const iv = crypto.getRandomValues(new Uint8Array(AES_GCM_IV_BYTES));
+  const encoded = new TextEncoder().encode(plaintext);
+  const cipherBuffer = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, encoded);
+  const cipher = new Uint8Array(cipherBuffer);
+
+  return [ENCRYPTED_VALUE_VERSION, toBase64(iv), toBase64(cipher)].join(":");
+}
+
+export async function decryptSecret(env: SecretCryptoEnv, encryptedValue: string): Promise<string> {
+  const parts = encryptedValue.split(":");
+  if (parts.length !== 3 || parts[0] !== ENCRYPTED_VALUE_VERSION) {
+    throw new Error("Unsupported encrypted secret format");
+  }
+
+  const key = await getCryptoKey(env);
+  const iv = fromBase64(parts[1]);
+  const cipher = fromBase64(parts[2]);
+
+  const plainBuffer = await crypto.subtle.decrypt({ name: "AES-GCM", iv }, key, cipher);
+  return new TextDecoder().decode(plainBuffer);
+}
+
+async function getCryptoKey(env: SecretCryptoEnv): Promise<CryptoKey> {
+  const rawKey = env.CREDENTIALS_ENCRYPTION_KEY?.trim();
+  if (!rawKey) {
+    throw new Error("CREDENTIALS_ENCRYPTION_KEY is required");
+  }
+
+  if (cachedKey && cachedRawKey === rawKey) {
+    return cachedKey;
+  }
+
+  const keyBytes = fromBase64(rawKey);
+  if (keyBytes.byteLength !== AES_256_KEY_BYTES) {
+    throw new Error("CREDENTIALS_ENCRYPTION_KEY must be a base64-encoded 32-byte key");
+  }
+
+  const key = await crypto.subtle.importKey("raw", keyBytes, "AES-GCM", false, [
+    "encrypt",
+    "decrypt",
+  ]);
+
+  cachedKey = key;
+  cachedRawKey = rawKey;
+  return key;
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+function fromBase64(value: string): Uint8Array {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/worker/src/lib/task-runs.ts
+++ b/worker/src/lib/task-runs.ts
@@ -2,9 +2,17 @@ import { and, desc, eq, isNull, not } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import * as schema from "../db/schema";
 import { createInstallationToken, buildAuthenticatedCloneUrl, type GitHubAppEnv } from "./github";
+import { readProviderAuthFromSandbox } from "./opencode-auth";
+import {
+  buildTaskRunSandboxId,
+  toProviderModelRef,
+  type SupportedOpencodeProvider,
+} from "./opencode";
+import { getDecryptedProviderAuth, upsertProviderAuthCredential } from "./provider-credentials";
 import { getTaskSandbox, getOpenCodeClient, type SandboxEnv } from "./sandbox";
+import type { SecretCryptoEnv } from "./secret-crypto";
 
-type TaskRunEnv = SandboxEnv & GitHubAppEnv;
+type TaskRunEnv = SandboxEnv & GitHubAppEnv & SecretCryptoEnv;
 
 export async function executeTaskRun(args: {
   db: DrizzleD1Database<typeof schema>;
@@ -15,8 +23,23 @@ export async function executeTaskRun(args: {
   prompt: string;
   repoUrl: string;
   installationId: number | null;
+  initiatedByUserId: string;
+  provider: SupportedOpencodeProvider;
+  model: string;
 }): Promise<void> {
-  const { db, env, runId, taskId, taskTitle, prompt, repoUrl, installationId } = args;
+  const {
+    db,
+    env,
+    runId,
+    taskId,
+    taskTitle,
+    prompt,
+    repoUrl,
+    installationId,
+    initiatedByUserId,
+    provider,
+    model,
+  } = args;
 
   try {
     const startedAt = Date.now();
@@ -32,9 +55,14 @@ export async function executeTaskRun(args: {
 
     await appendRunEvent(db, runId, "status", "running", startedAt);
 
-    // Get or resume sandbox for this task
-    const sandbox = getTaskSandbox(env, taskId);
-    const sandboxId = taskId;
+    // Scope sandbox by task+user+provider+model to avoid cross-user/provider leakage.
+    const sandboxId = buildTaskRunSandboxId({
+      taskId,
+      userId: initiatedByUserId,
+      provider,
+      model,
+    });
+    const sandbox = getTaskSandbox(env, sandboxId);
 
     await db
       .update(schema.taskRuns)
@@ -61,14 +89,29 @@ export async function executeTaskRun(args: {
       await sandbox.exec(`git -C ${repoDir} remote set-url origin '${freshUrl}'`);
     }
 
+    const providerAuth = await getDecryptedProviderAuth(db, env, initiatedByUserId, provider);
+    if (!providerAuth) {
+      throw new Error(`No ${provider} credentials configured. Add them in Settings first.`);
+    }
+
     // Start or connect to the OpenCode server and get a typed client
-    const { client } = await getOpenCodeClient(sandbox, repoDir);
+    const { client } = await getOpenCodeClient(sandbox, repoDir, {
+      enabled_providers: [provider],
+      model: toProviderModelRef(provider, model),
+    });
+    await client.auth.set({
+      path: { id: provider },
+      body: providerAuth,
+    });
 
     // Reuse an existing OpenCode session from a previous run, or create a new one
     const previousRun = await db.query.taskRuns.findFirst({
       where: and(
         eq(schema.taskRuns.taskId, taskId),
         eq(schema.taskRuns.tool, "opencode"),
+        eq(schema.taskRuns.initiatedByUserId, initiatedByUserId),
+        eq(schema.taskRuns.provider, provider),
+        eq(schema.taskRuns.model, model),
         not(isNull(schema.taskRuns.sessionId)),
       ),
       columns: { sessionId: true },
@@ -93,6 +136,14 @@ export async function executeTaskRun(args: {
         parts: [{ type: "text", text: prompt }],
       },
     });
+
+    // Persist the latest auth payload in case provider refresh tokens rotated.
+    try {
+      const refreshedAuth = await readProviderAuthFromSandbox(sandbox, provider);
+      if (refreshedAuth) {
+        await upsertProviderAuthCredential(db, env, initiatedByUserId, provider, refreshedAuth);
+      }
+    } catch {}
 
     // Extract text from the response parts
     const output = extractTextFromParts(response?.parts).trim();

--- a/worker/src/routes/settings.ts
+++ b/worker/src/routes/settings.ts
@@ -1,0 +1,426 @@
+import type { Sandbox } from "@cloudflare/sandbox";
+import { and, eq, lt } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { Hono } from "hono";
+import type { ProviderAuthMethod } from "@opencode-ai/sdk";
+import * as schema from "../db/schema";
+import { inspectProviderAuthFromSandbox, readProviderAuthFromSandbox } from "../lib/opencode-auth";
+import {
+  buildProviderAuthSandboxId,
+  DEFAULT_OPENCODE_PROVIDER,
+  isSupportedOpencodeProvider,
+  PROVIDER_OAUTH_ATTEMPT_TTL_MS,
+  type SupportedOpencodeProvider,
+} from "../lib/opencode";
+import {
+  deleteProviderCredential,
+  getProviderCredentialStatus,
+  upsertProviderApiKeyCredential,
+  upsertProviderAuthCredential,
+} from "../lib/provider-credentials";
+import { getOpenCodeClient, getTaskSandbox } from "../lib/sandbox";
+import type { SecretCryptoEnv } from "../lib/secret-crypto";
+
+const OAUTH_WORKDIR = "/home/user";
+
+type Env = {
+  Bindings: {
+    DB: D1Database;
+    Sandbox: DurableObjectNamespace<Sandbox>;
+  } & SecretCryptoEnv;
+  Variables: {
+    db: DrizzleD1Database<typeof schema>;
+    session: {
+      session: { userId: string; activeOrganizationId?: string | null };
+      user: { id: string; name: string; email: string; image?: string | null };
+    };
+  };
+};
+
+const settings = new Hono<Env>();
+
+settings.get("/providers/:provider", async (c) => {
+  const db = c.get("db");
+  const userId = c.get("session").user.id;
+  const provider = parseProvider(c.req.param("provider"));
+
+  if (!provider) {
+    return c.json({ error: "Unsupported provider" }, 400);
+  }
+
+  const status = await getProviderCredentialStatus(db, userId, provider);
+  return c.json(status);
+});
+
+settings.put("/providers/:provider", async (c) => {
+  const db = c.get("db");
+  const userId = c.get("session").user.id;
+  const provider = parseProvider(c.req.param("provider"));
+
+  if (!provider) {
+    return c.json({ error: "Unsupported provider" }, 400);
+  }
+
+  let body: { apiKey?: string };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const apiKey = body.apiKey?.trim() ?? "";
+  if (apiKey.length === 0) {
+    return c.json({ error: "apiKey is required" }, 400);
+  }
+
+  const status = await upsertProviderApiKeyCredential(db, c.env, userId, provider, apiKey);
+  return c.json(status);
+});
+
+settings.post("/providers/:provider/oauth/start", async (c) => {
+  const db = c.get("db");
+  const userId = c.get("session").user.id;
+  const provider = parseProvider(c.req.param("provider"));
+  const requestId = crypto.randomUUID();
+
+  if (!provider) {
+    return c.json({ error: "Unsupported provider" }, 400);
+  }
+  console.info("Provider OAuth start requested", { requestId, userId, provider });
+
+  const sandboxId = buildProviderAuthSandboxId({ userId, provider });
+  const sandbox = getTaskSandbox(c.env, sandboxId);
+  const { client } = await getOpenCodeClient(sandbox, OAUTH_WORKDIR, undefined, {
+    restartServer: false,
+  });
+
+  const methodsResponse = await client.provider.auth();
+  const methods = methodsResponse.data?.[provider] ?? [];
+  const oauthMethod = pickOAuthMethod(methods);
+  console.info("Provider OAuth methods resolved", {
+    requestId,
+    userId,
+    provider,
+    methodCount: methods.length,
+    selectedMethod: oauthMethod,
+    methodLabels: methods.map((method) => `${method.type}:${method.label}`),
+  });
+  if (oauthMethod === null) {
+    return c.json({ error: `No OAuth method available for ${provider}` }, 400);
+  }
+
+  const authorizeResponse = await client.provider.oauth.authorize({
+    path: { id: provider },
+    body: { method: oauthMethod },
+  });
+
+  const authorization = authorizeResponse.data;
+  if (!authorization?.url) {
+    console.warn("Provider OAuth authorize response missing URL", {
+      requestId,
+      userId,
+      provider,
+      selectedMethod: oauthMethod,
+    });
+    return c.json({ error: "Failed to start provider OAuth flow" }, 500);
+  }
+
+  const now = Date.now();
+  const attemptId = crypto.randomUUID();
+  const expiresAt = now + PROVIDER_OAUTH_ATTEMPT_TTL_MS;
+
+  await db
+    .delete(schema.userProviderOauthAttempts)
+    .where(
+      and(
+        eq(schema.userProviderOauthAttempts.userId, userId),
+        eq(schema.userProviderOauthAttempts.provider, provider),
+      ),
+    );
+
+  await db.insert(schema.userProviderOauthAttempts).values({
+    id: attemptId,
+    userId,
+    provider,
+    sandboxId,
+    method: oauthMethod,
+    createdAt: now,
+    expiresAt,
+  });
+  console.info("Provider OAuth attempt created", {
+    requestId,
+    userId,
+    provider,
+    attemptId,
+    sandboxId,
+    selectedMethod: oauthMethod,
+    authorizationMethod: authorization.method,
+    expiresAt,
+  });
+
+  return c.json({
+    attemptId,
+    url: authorization.url,
+    instructions: authorization.instructions,
+    method: authorization.method,
+    expiresAt,
+  });
+});
+
+settings.post("/providers/:provider/oauth/complete", async (c) => {
+  const db = c.get("db");
+  const userId = c.get("session").user.id;
+  const provider = parseProvider(c.req.param("provider"));
+  const requestId = crypto.randomUUID();
+
+  if (!provider) {
+    return c.json({ error: "Unsupported provider" }, 400);
+  }
+
+  let body: { attemptId?: string; code?: string };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const attemptId = body.attemptId?.trim() ?? "";
+  if (attemptId.length === 0) {
+    return c.json({ error: "attemptId is required" }, 400);
+  }
+  const code = body.code?.trim() ?? "";
+  console.info("Provider OAuth completion requested", {
+    requestId,
+    userId,
+    provider,
+    attemptId,
+    hasCode: code.length > 0,
+  });
+
+  await db
+    .delete(schema.userProviderOauthAttempts)
+    .where(lt(schema.userProviderOauthAttempts.expiresAt, Date.now()));
+
+  const attempt = await db.query.userProviderOauthAttempts.findFirst({
+    where: and(
+      eq(schema.userProviderOauthAttempts.id, attemptId),
+      eq(schema.userProviderOauthAttempts.userId, userId),
+      eq(schema.userProviderOauthAttempts.provider, provider),
+    ),
+  });
+  if (!attempt) {
+    console.warn("Provider OAuth attempt missing on completion", {
+      requestId,
+      userId,
+      provider,
+      attemptId,
+    });
+    return c.json({ error: "OAuth attempt not found or expired" }, 400);
+  }
+  console.info("Provider OAuth attempt loaded for completion", {
+    requestId,
+    userId,
+    provider,
+    attemptId: attempt.id,
+    sandboxId: attempt.sandboxId,
+    method: attempt.method,
+    expiresAt: attempt.expiresAt,
+  });
+
+  const sandbox = getTaskSandbox(c.env, attempt.sandboxId);
+  const { client } = await getOpenCodeClient(sandbox, OAUTH_WORKDIR, undefined, {
+    restartServer: false,
+  });
+
+  let callbackResponse: Awaited<ReturnType<typeof client.provider.oauth.callback>>;
+  try {
+    callbackResponse = await client.provider.oauth.callback({
+      path: { id: provider },
+      body: code.length > 0 ? { method: attempt.method, code } : { method: attempt.method },
+    });
+  } catch (error) {
+    console.warn("Provider OAuth callback request failed", {
+      requestId,
+      userId,
+      provider,
+      attemptId: attempt.id,
+      method: attempt.method,
+      error: extractErrorMessage(error),
+    });
+    return c.json({ error: toProviderOauthCallbackError(error) }, 400);
+  }
+
+  const callbackError = extractErrorMessage((callbackResponse as { error?: unknown }).error);
+  console.info("Provider OAuth callback returned", {
+    requestId,
+    userId,
+    provider,
+    attemptId: attempt.id,
+    callbackSucceeded: Boolean(callbackResponse.data),
+    callbackError,
+  });
+  if (!callbackResponse.data) {
+    if (callbackError) {
+      return c.json({ error: toProviderOauthCallbackError(callbackError) }, 400);
+    }
+
+    return c.json({ error: "Provider OAuth callback did not complete" }, 400);
+  }
+
+  const providerAuth = await readProviderAuthFromSandbox(sandbox, provider);
+  if (!providerAuth) {
+    const inspection = await inspectProviderAuthFromSandbox(sandbox, provider);
+    console.error("Provider OAuth callback succeeded but auth token not found", {
+      requestId,
+      userId,
+      provider,
+      attemptId: attempt.id,
+      inspection,
+    });
+    return c.json(
+      {
+        error:
+          "Provider OAuth completed but no auth token was found in the OpenCode sandbox. Start OAuth again and retry completion.",
+      },
+      500,
+    );
+  }
+
+  let status;
+  try {
+    status = await upsertProviderAuthCredential(db, c.env, userId, provider, providerAuth);
+  } catch (error) {
+    const message = toCredentialPersistError(error);
+    console.error("Failed to persist provider OAuth credential", {
+      userId,
+      provider,
+      message,
+    });
+    return c.json({ error: message }, 500);
+  }
+  console.info("Provider OAuth credentials persisted", {
+    requestId,
+    userId,
+    provider,
+    attemptId: attempt.id,
+    authType: providerAuth.type,
+  });
+
+  await db
+    .delete(schema.userProviderOauthAttempts)
+    .where(eq(schema.userProviderOauthAttempts.id, attempt.id));
+  console.info("Provider OAuth attempt cleared after completion", {
+    requestId,
+    userId,
+    provider,
+    attemptId: attempt.id,
+  });
+
+  return c.json(status);
+});
+
+settings.delete("/providers/:provider", async (c) => {
+  const db = c.get("db");
+  const userId = c.get("session").user.id;
+  const provider = parseProvider(c.req.param("provider"));
+
+  if (!provider) {
+    return c.json({ error: "Unsupported provider" }, 400);
+  }
+
+  await deleteProviderCredential(db, userId, provider);
+  await db
+    .delete(schema.userProviderOauthAttempts)
+    .where(
+      and(
+        eq(schema.userProviderOauthAttempts.userId, userId),
+        eq(schema.userProviderOauthAttempts.provider, provider),
+      ),
+    );
+
+  return c.json({ provider, configured: false, authType: null, updatedAt: null });
+});
+
+function parseProvider(value: string): SupportedOpencodeProvider | null {
+  const normalized = value.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return DEFAULT_OPENCODE_PROVIDER;
+  }
+
+  return isSupportedOpencodeProvider(normalized) ? normalized : null;
+}
+
+function pickOAuthMethod(methods: ProviderAuthMethod[]): number | null {
+  let firstOauth: number | null = null;
+
+  for (const [index, method] of methods.entries()) {
+    if (method.type !== "oauth") {
+      continue;
+    }
+
+    if (firstOauth === null) {
+      firstOauth = index;
+    }
+
+    const label = method.label.toLowerCase();
+    if (label.includes("headless")) {
+      return index;
+    }
+  }
+
+  return firstOauth;
+}
+
+function extractErrorMessage(error: unknown): string | null {
+  if (!error) {
+    return null;
+  }
+
+  if (typeof error === "string") {
+    const normalized = error.trim();
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  if (error instanceof Error) {
+    const normalized = error.message.trim();
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  if (typeof error === "object" && error !== null) {
+    const record = error as { message?: unknown; detail?: unknown; error?: unknown };
+    for (const candidate of [record.message, record.detail, record.error]) {
+      if (typeof candidate === "string" && candidate.trim().length > 0) {
+        return candidate.trim();
+      }
+    }
+  }
+
+  return null;
+}
+
+function toProviderOauthCallbackError(error: unknown): string {
+  const message = extractErrorMessage(error) ?? "Provider OAuth callback failed";
+  if (message.includes("ProviderAuthOauthCodeMissing")) {
+    return "Provider OAuth callback requires an authorization code.";
+  }
+  if (message.includes("ProviderAuthOauthMissing")) {
+    return "Provider OAuth attempt expired or was lost. Start the OAuth flow again.";
+  }
+  if (message.includes("ProviderAuthOauthCallbackFailed")) {
+    return "Provider OAuth callback failed. Complete sign-in in the provider page and retry.";
+  }
+  return message;
+}
+
+function toCredentialPersistError(error: unknown): string {
+  const message = extractErrorMessage(error);
+  if (!message) {
+    return "Failed to save provider credentials";
+  }
+  if (message.includes("CREDENTIALS_ENCRYPTION_KEY")) {
+    return "CREDENTIALS_ENCRYPTION_KEY is missing or invalid in the worker environment.";
+  }
+  return message;
+}
+
+export { settings };

--- a/worker/src/routes/tasks.ts
+++ b/worker/src/routes/tasks.ts
@@ -3,6 +3,11 @@ import { and, desc, eq, gt } from "drizzle-orm";
 import { drizzle, type DrizzleD1Database } from "drizzle-orm/d1";
 import type { Sandbox } from "@cloudflare/sandbox";
 import * as schema from "../db/schema";
+import {
+  DEFAULT_OPENCODE_MODEL,
+  DEFAULT_OPENCODE_PROVIDER,
+  isSupportedOpencodeProvider,
+} from "../lib/opencode";
 import { executeTaskRun } from "../lib/task-runs";
 
 type Env = {
@@ -11,6 +16,7 @@ type Env = {
     Sandbox: DurableObjectNamespace<Sandbox>;
     GITHUB_APP_ID?: string;
     GITHUB_APP_PRIVATE_KEY?: string;
+    CREDENTIALS_ENCRYPTION_KEY: string;
   };
   Variables: {
     db: DrizzleD1Database<typeof schema>;
@@ -26,6 +32,10 @@ const tasks = new Hono<Env>();
 function getOrgId(c: { get: (key: "session") => Env["Variables"]["session"] }): string | null {
   const session = c.get("session");
   return (session.session as { activeOrganizationId?: string | null }).activeOrganizationId ?? null;
+}
+
+function getUserId(c: { get: (key: "session") => Env["Variables"]["session"] }): string {
+  return c.get("session").user.id;
 }
 
 async function getTaskForOrg(
@@ -321,89 +331,129 @@ tasks.post("/:taskId/runs", async (c) => {
   const db = c.get("db");
   const { taskId } = c.req.param();
   const orgId = getOrgId(c);
+  const userId = getUserId(c);
 
-  if (!orgId) {
-    return c.json({ error: "No active organization" }, 400);
-  }
-
-  const task = await getTaskForOrg(db, taskId, orgId);
-  if (!task) {
-    return c.json({ error: "Task not found" }, 404);
-  }
-
-  let body: { messageId?: string };
   try {
-    body = await c.req.json();
-  } catch {
-    body = {};
-  }
+    if (!orgId) {
+      return c.json({ error: "No active organization" }, 400);
+    }
 
-  const inputMessage = body.messageId
-    ? await db.query.taskMessages.findFirst({
-        where: and(
-          eq(schema.taskMessages.id, body.messageId),
-          eq(schema.taskMessages.taskId, taskId),
-          eq(schema.taskMessages.role, "user"),
-        ),
-      })
-    : await db.query.taskMessages.findFirst({
-        where: and(eq(schema.taskMessages.taskId, taskId), eq(schema.taskMessages.role, "user")),
-        orderBy: desc(schema.taskMessages.createdAt),
-      });
+    const task = await getTaskForOrg(db, taskId, orgId);
+    if (!task) {
+      return c.json({ error: "Task not found" }, 404);
+    }
 
-  if (!inputMessage) {
-    return c.json({ error: "No user message found for this task" }, 400);
-  }
+    let body: { messageId?: string; provider?: string; model?: string };
+    try {
+      body = await c.req.json();
+    } catch {
+      body = {};
+    }
 
-  const now = Date.now();
-  const run = {
-    id: crypto.randomUUID(),
-    taskId,
-    tool: "opencode",
-    status: "queued",
-    inputMessageId: inputMessage.id,
-    outputMessageId: null,
-    sandboxId: null,
-    sessionId: null,
-    error: null,
-    startedAt: null,
-    finishedAt: null,
-    createdAt: now,
-    updatedAt: now,
-  };
+    const requestedProvider = body.provider?.trim().toLowerCase() ?? "";
+    const providerInput =
+      requestedProvider.length > 0 ? requestedProvider : DEFAULT_OPENCODE_PROVIDER;
+    if (!isSupportedOpencodeProvider(providerInput)) {
+      return c.json({ error: `Unsupported provider: ${providerInput}` }, 400);
+    }
 
-  await db.insert(schema.taskRuns).values(run);
-  await db.insert(schema.taskRunEvents).values({
-    id: crypto.randomUUID(),
-    runId: run.id,
-    kind: "status",
-    payload: "queued",
-    createdAt: now,
-  });
+    const model = body.model?.trim() ?? DEFAULT_OPENCODE_MODEL;
+    if (model.length === 0) {
+      return c.json({ error: "model is required" }, 400);
+    }
 
-  const project = await db.query.projects.findFirst({
-    where: eq(schema.projects.id, task.projectId!),
-    columns: { repoUrl: true, installationId: true },
-  });
+    const hasCredential = await db.query.userProviderCredentials.findFirst({
+      where: and(
+        eq(schema.userProviderCredentials.userId, userId),
+        eq(schema.userProviderCredentials.provider, providerInput),
+      ),
+      columns: { id: true },
+    });
+    if (!hasCredential) {
+      return c.json({ error: `No ${providerInput} credentials configured in Settings` }, 400);
+    }
 
-  if (!project?.repoUrl) {
-    return c.json({ error: "Task's project has no repository URL configured" }, 400);
-  }
+    const inputMessage = body.messageId
+      ? await db.query.taskMessages.findFirst({
+          where: and(
+            eq(schema.taskMessages.id, body.messageId),
+            eq(schema.taskMessages.taskId, taskId),
+            eq(schema.taskMessages.role, "user"),
+          ),
+        })
+      : await db.query.taskMessages.findFirst({
+          where: and(eq(schema.taskMessages.taskId, taskId), eq(schema.taskMessages.role, "user")),
+          orderBy: desc(schema.taskMessages.createdAt),
+        });
 
-  c.executionCtx.waitUntil(
-    executeTaskRun({
-      db: drizzle(c.env.DB, { schema }),
-      env: c.env,
-      runId: run.id,
+    if (!inputMessage) {
+      return c.json({ error: "No user message found for this task" }, 400);
+    }
+
+    const now = Date.now();
+    const run = {
+      id: crypto.randomUUID(),
       taskId,
-      taskTitle: task.title,
-      prompt: inputMessage.content,
-      repoUrl: project.repoUrl,
-      installationId: project.installationId ?? null,
-    }),
-  );
+      tool: "opencode",
+      status: "queued",
+      inputMessageId: inputMessage.id,
+      outputMessageId: null,
+      sandboxId: null,
+      sessionId: null,
+      initiatedByUserId: userId,
+      provider: providerInput,
+      model,
+      error: null,
+      startedAt: null,
+      finishedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    };
 
-  return c.json(run, 202);
+    await db.insert(schema.taskRuns).values(run);
+    await db.insert(schema.taskRunEvents).values({
+      id: crypto.randomUUID(),
+      runId: run.id,
+      kind: "status",
+      payload: "queued",
+      createdAt: now,
+    });
+
+    const project = await db.query.projects.findFirst({
+      where: eq(schema.projects.id, task.projectId!),
+      columns: { repoUrl: true, installationId: true },
+    });
+
+    if (!project?.repoUrl) {
+      return c.json({ error: "Task's project has no repository URL configured" }, 400);
+    }
+
+    c.executionCtx.waitUntil(
+      executeTaskRun({
+        db: drizzle(c.env.DB, { schema }),
+        env: c.env,
+        runId: run.id,
+        taskId,
+        taskTitle: task.title,
+        prompt: inputMessage.content,
+        repoUrl: project.repoUrl,
+        installationId: project.installationId ?? null,
+        initiatedByUserId: userId,
+        provider: providerInput,
+        model,
+      }),
+    );
+
+    return c.json(run, 202);
+  } catch (error) {
+    const message = getErrorMessage(error);
+    console.error("Failed to create task run", {
+      taskId,
+      userId,
+      message,
+    });
+    return c.json({ error: message }, 500);
+  }
 });
 
 // GET /api/tasks/runs/:runId — single run
@@ -469,3 +519,11 @@ tasks.get("/runs/:runId/events", async (c) => {
 });
 
 export { tasks };
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+
+  return "Failed to create task run";
+}


### PR DESCRIPTION
Adds encrypted provider credential storage, OAuth start/complete endpoints, and settings UI to manage OpenAI API key or ChatGPT OAuth.\nIt updates task runs to use provider/model/user-aware auth and sandbox scoping, with better error propagation to the UI.\nIt also includes the sandbox ID length fix and task run feedback visibility updates so failed starts are no longer silent.\n\nValidation: bun run format, bun run lint:fix, bun run build.