### PR TITLE
Align task overview messages to the left

### DIFF
--- a/frontend/src/pages/task-page.tsx
+++ b/frontend/src/pages/task-page.tsx
@@ -313,15 +313,12 @@ export function TaskPage() {
         ) : (
           <div className="mx-auto max-w-3xl space-y-4 px-4 py-4">
             {orderedMessages.map((msg) => (
-              <div
-                key={msg.id}
-                className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}
-              >
+              <div key={msg.id} className="flex justify-start">
                 <div
-                  className={`max-w-[80%] rounded-lg px-4 py-2.5 text-sm whitespace-pre-wrap ${
+                  className={`max-w-[80%] text-sm whitespace-pre-wrap ${
                     msg.role === "user"
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-muted text-foreground"
+                      ? "rounded-lg bg-primary px-4 py-2.5 text-primary-foreground"
+                      : "text-foreground"
                   }`}
                 >
                   {msg.content}


### PR DESCRIPTION
This updates the task overview message list so user and assistant messages are both left-aligned. User messages keep their boxed primary styling, while assistant messages render without a background. This matches the requested conversation layout behavior.