### PR TITLE
Remove .dev.vars copy from setup script

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "bun i && cd frontend && mkdir dist && cd .. && cp $CONDUCTOR_ROOT_PATH/.dev.vars .dev.vars && cp $CONDUCTOR_ROOT_PATH/.env .env",
+    "setup": "bun i && cd frontend && mkdir dist && cd .. && cp $CONDUCTOR_ROOT_PATH/.env .env",
     "run": "bun run dev",
     "archive": "rm -rf "
   }


### PR DESCRIPTION
This updates the Conductor setup script to only copy .env from CONDUCTOR_ROOT_PATH. It removes the .dev.vars copy step from setup.