### PR TITLE
refactor: shared on-demand task messages

### DIFF
--- a/frontend/src/components/add-project-dialog.tsx
+++ b/frontend/src/components/add-project-dialog.tsx
@@ -10,8 +10,8 @@ import {
   createProjects,
   type Installation,
   type GitHubRepo,
-  type Project,
 } from "../lib/api";
+import { Project } from "@/lib/collections";
 
 interface RepoWithInstallation extends GitHubRepo {
   installationId: number;
@@ -36,7 +36,7 @@ export function AddProjectDialog({
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const existingRepoUrls = new Set(existingProjects.map((p) => p.repoUrl).filter(Boolean));
+  const existingRepoUrls = new Set(existingProjects.map((p) => p.repo_url).filter(Boolean));
 
   const loadData = useCallback(async () => {
     setLoading(true);

--- a/frontend/src/components/layout/task-list.tsx
+++ b/frontend/src/components/layout/task-list.tsx
@@ -16,8 +16,12 @@ import { createTask, deleteTask } from "../../lib/api";
 import { projectsCollection, tasksCollection } from "../../lib/collections";
 
 export function TaskList() {
-  const { data: tasks, isLoading } = useLiveQuery((query) => query.from({ t: tasksCollection }));
-  const { data: projects } = useLiveQuery((query) => query.from({ p: projectsCollection }));
+  const { data: tasks, isLoading } = useLiveQuery((query) =>
+    query.from({ t: tasksCollection }).orderBy(({ t }) => t.updated_at, "desc"),
+  );
+  const { data: projects } = useLiveQuery((query) =>
+    query.from({ p: projectsCollection }).orderBy(({ p }) => p.created_at, "asc"),
+  );
   const navigate = useNavigate();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
   const [creating, setCreating] = useState(false);
@@ -25,25 +29,7 @@ export function TaskList() {
   const [taskToDelete, setTaskToDelete] = useState<{ id: string; title: string } | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
-  const sortedTasks = tasks
-    ? [...tasks].toSorted((a, b) => {
-        const updatedDiff = b.updatedAt - a.updatedAt;
-        if (updatedDiff !== 0) {
-          return updatedDiff;
-        }
-        return a.id.localeCompare(b.id);
-      })
-    : tasks;
-  const sortedProjects = projects
-    ? [...projects].toSorted((a, b) => {
-        const createdDiff = b.createdAt - a.createdAt;
-        if (createdDiff !== 0) {
-          return createdDiff;
-        }
-        return a.id.localeCompare(b.id);
-      })
-    : projects;
-  const defaultProject = sortedProjects?.[0];
+  const [defaultProject] = projects;
 
   async function handleNewTask() {
     if (creating || !defaultProject) return;
@@ -125,12 +111,12 @@ export function TaskList() {
           <div className="flex items-center justify-center py-6 text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
           </div>
-        ) : !sortedTasks || sortedTasks.length === 0 ? (
+        ) : tasks.length === 0 ? (
           <div className="px-2 py-6 text-center">
             <p className="text-xs text-muted-foreground">No tasks yet</p>
           </div>
         ) : (
-          sortedTasks.map((task) => {
+          tasks.map((task) => {
             const isActive = pathname === `/tasks/${task.id}`;
             return (
               <div

--- a/frontend/src/lib/collections.ts
+++ b/frontend/src/lib/collections.ts
@@ -6,30 +6,31 @@ const BASE_URL = globalThis.location?.origin;
 
 const projectSchema = z.object({
   id: z.string(),
-  organizationId: z.string(),
+  organization_id: z.string(),
   name: z.string(),
-  repoUrl: z.string().nullable(),
-  installationId: z.number().nullable(),
-  createdAt: z.number().int(),
-  updatedAt: z.number().int(),
+  repo_url: z.string().nullable(),
+  installation_id: z.number().nullable(),
+  created_at: z.bigint(),
+  updated_at: z.bigint(),
 });
+export type Project = z.infer<typeof projectSchema>;
 
 const taskSchema = z.object({
   id: z.string(),
-  organizationId: z.string(),
-  projectId: z.string().nullable(),
+  organization_id: z.string(),
+  project_id: z.string().nullable(),
   title: z.string(),
   status: z.string(),
-  createdAt: z.number().int(),
-  updatedAt: z.number().int(),
+  created_at: z.bigint(),
+  updated_at: z.bigint(),
 });
 
 const taskMessageSchema = z.object({
   id: z.string(),
-  taskId: z.string(),
+  task_id: z.string(),
   role: z.string(),
   content: z.string(),
-  createdAt: z.number().int(),
+  created_at: z.bigint(),
 });
 
 // ---- Projects collection ----
@@ -64,7 +65,6 @@ export const taskMessagesCollection = createCollection(
     shapeOptions: {
       url: `${BASE_URL}/api/tasks/messages/shape`,
     },
-    syncMode: "on-demand",
     getKey: (m) => m.id,
   }),
 );

--- a/frontend/src/pages/index-redirect.tsx
+++ b/frontend/src/pages/index-redirect.tsx
@@ -5,30 +5,23 @@ import { Loader2 } from "lucide-react";
 import { tasksCollection } from "../lib/collections";
 
 export function IndexRedirect() {
-  const { data: tasks, isLoading } = useLiveQuery((q) => q.from({ t: tasksCollection }));
-  const sortedTasks = tasks
-    ? [...tasks].toSorted((a, b) => {
-        const updatedDiff = b.updatedAt - a.updatedAt;
-        if (updatedDiff !== 0) {
-          return updatedDiff;
-        }
-        return a.id.localeCompare(b.id);
-      })
-    : tasks;
+  const { data: tasks, isLoading } = useLiveQuery((q) =>
+    q.from({ t: tasksCollection }).orderBy(({ t }) => t.updated_at, "desc"),
+  );
   const navigate = useNavigate();
 
   useEffect(() => {
     if (isLoading) return;
 
-    if (sortedTasks && sortedTasks.length > 0) {
+    if (tasks.length > 0) {
       navigate({
         to: "/tasks/$taskId",
-        params: { taskId: sortedTasks[0].id },
+        params: { taskId: tasks[0].id },
         replace: true,
       });
     }
     // If no tasks, stay on the index page — sidebar shows "No tasks yet"
-  }, [isLoading, sortedTasks, navigate]);
+  }, [isLoading, tasks, navigate]);
 
   if (isLoading) {
     return (

--- a/frontend/src/pages/settings-page.tsx
+++ b/frontend/src/pages/settings-page.tsx
@@ -17,17 +17,15 @@ import { projectsCollection } from "../lib/collections";
 
 const OPENAI_PROVIDER = "openai";
 
+function formatMsTimestamp(msTimestamp: bigint): string {
+  return new Date(Number(msTimestamp)).toLocaleDateString();
+}
+
 export function SettingsPage() {
-  const { data: projects, isLoading } = useLiveQuery((q) => q.from({ p: projectsCollection }));
-  const sortedProjects = projects
-    ? [...projects].toSorted((a, b) => {
-        const createdDiff = b.createdAt - a.createdAt;
-        if (createdDiff !== 0) {
-          return createdDiff;
-        }
-        return a.id.localeCompare(b.id);
-      })
-    : projects;
+  const { data: projects, isLoading } = useLiveQuery((q) =>
+    q.from({ p: projectsCollection }).orderBy(({ p }) => p.created_at, "asc"),
+  );
+
   const [dialogOpen, setDialogOpen] = useState(false);
   const [openaiApiKey, setOpenaiApiKey] = useState("");
   const [openaiStatus, setOpenaiStatus] = useState<ProviderCredentialStatus | null>(null);
@@ -254,28 +252,28 @@ export function SettingsPage() {
             <div className="flex items-center justify-center py-12 text-muted-foreground">
               <Loader2 className="h-5 w-5 animate-spin" />
             </div>
-          ) : !sortedProjects || sortedProjects.length === 0 ? (
+          ) : projects.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-border border-dashed py-12 text-muted-foreground">
               <BookMarked className="h-8 w-8" />
               <p className="text-sm">No projects yet. Add a repository to get started.</p>
             </div>
           ) : (
             <div className="space-y-2">
-              {sortedProjects.map((project) => (
+              {projects.map((project) => (
                 <Card key={project.id} className="gap-0 py-0">
                   <CardContent className="p-4">
                     <div className="flex items-center gap-3">
                       <BookMarked className="h-4 w-4 shrink-0 text-muted-foreground" />
                       <div className="min-w-0">
                         <p className="truncate text-sm font-medium">{project.name}</p>
-                        {project.repoUrl ? (
+                        {project.repo_url ? (
                           <p className="truncate text-xs text-muted-foreground">
-                            {project.repoUrl}
+                            {project.repo_url}
                           </p>
                         ) : null}
                       </div>
                       <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-                        {new Date(project.createdAt).toLocaleDateString()}
+                        {formatMsTimestamp(project.created_at)}
                       </span>
                     </div>
                   </CardContent>
@@ -290,7 +288,7 @@ export function SettingsPage() {
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
         onCreated={handleCreated}
-        existingProjects={sortedProjects ?? []}
+        existingProjects={projects}
       />
     </div>
   );

--- a/frontend/src/pages/task-page.tsx
+++ b/frontend/src/pages/task-page.tsx
@@ -1,6 +1,5 @@
-import { eq } from "@tanstack/db";
 import { useEffect, useRef, useState } from "react";
-import { useLiveQuery } from "@tanstack/react-db";
+import { useLiveQuery, eq } from "@tanstack/react-db";
 import { useParams } from "@tanstack/react-router";
 import { Check, Loader2, Pencil, Send, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -42,23 +41,13 @@ export function TaskPage() {
 
   const { data: messages, isLoading } = useLiveQuery(
     (q) =>
-      taskId ? q.from({ m: taskMessagesCollection }).where(({ m }) => eq(m.taskId, taskId)) : null,
+      q
+        .from({ m: taskMessagesCollection })
+        .where(({ m }) => eq(m.task_id, taskId))
+        .orderBy(({ m }) => m.created_at, "asc"),
     [taskId],
   );
-  const orderedMessages = messages
-    ? [...messages].toSorted((a, b) => {
-        const createdDiff = a.createdAt - b.createdAt;
-        if (createdDiff !== 0) {
-          return createdDiff;
-        }
 
-        if (a.role !== b.role) {
-          return a.role === "user" ? -1 : 1;
-        }
-
-        return a.id.localeCompare(b.id);
-      })
-    : messages;
   const hasRunFeedback = activeRunId !== null || runStatus !== null || runError !== null;
 
   useEffect(() => {
@@ -306,14 +295,14 @@ export function TaskPage() {
           <div className="flex items-center justify-center py-12 text-muted-foreground">
             <Loader2 className="h-5 w-5 animate-spin" />
           </div>
-        ) : !orderedMessages || orderedMessages.length === 0 ? (
+        ) : messages.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center gap-2 px-4 text-muted-foreground">
             <p className="text-sm">No messages yet</p>
             <p className="text-xs">Send a message to start an OpenCode run.</p>
           </div>
         ) : (
           <div className="mx-auto max-w-3xl space-y-4 px-4 py-4">
-            {orderedMessages.map((msg) => (
+            {messages.map((msg) => (
               <div key={msg.id} className="flex justify-start">
                 <div
                   className={`max-w-[80%] text-sm whitespace-pre-wrap ${

--- a/worker/migrations-postgres/0002_task_messages_org.sql
+++ b/worker/migrations-postgres/0002_task_messages_org.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "task_messages" ADD COLUMN "organization_id" text;
+--> statement-breakpoint
+UPDATE "task_messages"
+SET "organization_id" = "tasks"."organization_id"
+FROM "tasks"
+WHERE "tasks"."id" = "task_messages"."task_id";
+--> statement-breakpoint
+ALTER TABLE "task_messages" ALTER COLUMN "organization_id" SET NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "task_messages" ADD CONSTRAINT "task_messages_organization_id_organization_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organization"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX "task_message_org" ON "task_messages" USING btree ("organization_id","created_at");

--- a/worker/migrations-postgres/meta/_journal.json
+++ b/worker/migrations-postgres/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1770995898651,
       "tag": "0001_striped_wong",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1771300800000,
+      "tag": "0002_task_messages_org",
+      "breakpoints": true
     }
   ]
 }

--- a/worker/migrations/0010_task_messages_org.sql
+++ b/worker/migrations/0010_task_messages_org.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `task_messages` ADD `organization_id` text;
+--> statement-breakpoint
+UPDATE `task_messages`
+SET `organization_id` = `tasks`.`organization_id`
+FROM `tasks`
+WHERE `tasks`.`id` = `task_messages`.`task_id`;
+--> statement-breakpoint
+CREATE INDEX `task_message_org` ON `task_messages` (`organization_id`, `created_at`);

--- a/worker/migrations/meta/_journal.json
+++ b/worker/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1771286400000,
       "tag": "0009_breezy_polaris",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1771300800000,
+      "tag": "0010_task_messages_org",
+      "breakpoints": true
     }
   ]
 }

--- a/worker/src/db/schema.ts
+++ b/worker/src/db/schema.ts
@@ -375,6 +375,9 @@ export const taskMessages = pgTable(
   "task_messages",
   {
     id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
     taskId: text("task_id")
       .notNull()
       .references(() => tasks.id, { onDelete: "cascade" }),
@@ -382,7 +385,10 @@ export const taskMessages = pgTable(
     content: text("content").notNull(),
     createdAt: msTimestamp("created_at").notNull(),
   },
-  (t) => [index("task_message_task").on(t.taskId, t.createdAt)],
+  (t) => [
+    index("task_message_org").on(t.organizationId, t.createdAt),
+    index("task_message_task").on(t.taskId, t.createdAt),
+  ],
 );
 
 // ---------------------------------------------------------------------------

--- a/worker/src/lib/task-runs.ts
+++ b/worker/src/lib/task-runs.ts
@@ -19,6 +19,7 @@ export async function executeTaskRun(args: {
   env: TaskRunEnv;
   runId: string;
   taskId: string;
+  organizationId: string;
   taskTitle: string;
   prompt: string;
   repoUrl: string;
@@ -32,6 +33,7 @@ export async function executeTaskRun(args: {
     env,
     runId,
     taskId,
+    organizationId,
     taskTitle,
     prompt,
     repoUrl,
@@ -154,6 +156,7 @@ export async function executeTaskRun(args: {
 
     await db.insert(schema.taskMessages).values({
       id: assistantMessageId,
+      organizationId,
       taskId,
       role: "assistant",
       content: assistantOutput,

--- a/worker/src/routes/tasks.ts
+++ b/worker/src/routes/tasks.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gt, sql } from "drizzle-orm";
+import { and, desc, eq, gt } from "drizzle-orm";
 import { Hono } from "hono";
 import type { Sandbox } from "@cloudflare/sandbox";
 import type { AppDb } from "../db/client";
@@ -244,17 +244,13 @@ tasks.get("/messages/shape", async (c) => {
     return c.json({ error: "No active organization" }, 400);
   }
 
-  return electricFn({
+  const result = await electricFn({
     request: c.req.raw,
     table: "task_messages",
-    where: clauseToString(
-      sql`${schema.taskMessages.taskId} in (
-        select ${schema.tasks.id}
-        from ${schema.tasks}
-        where ${schema.tasks.organizationId} = ${orgId}
-      )`,
-    ),
+    where: clauseToString(eq(schema.taskMessages.organizationId, orgId)),
   });
+
+  return result;
 });
 
 tasks.get("/:taskId/messages/shape", async (c) => {
@@ -312,6 +308,7 @@ tasks.post("/:taskId/messages", async (c) => {
     const now = await getNextTaskMessageTimestamp(tx as unknown as AppDb, taskId);
     const message = {
       id: crypto.randomUUID(),
+      organizationId: orgId,
       taskId,
       role: body.role,
       content: body.content.trim(),
@@ -470,6 +467,7 @@ tasks.post("/:taskId/runs", async (c) => {
         repoUrl: project.repoUrl,
         installationId: project.installationId ?? null,
         initiatedByUserId: userId,
+        organizationId: orgId,
         provider: providerInput,
         model,
       }),


### PR DESCRIPTION
This switches task messages from per-task Electric collections to a single shared on-demand collection.\nThe task page now filters messages by taskId in the live query and still awaits message txid sync before starting runs.\nThe worker now exposes an org-scoped /api/tasks/messages/shape endpoint for the shared collection.\nFormat and lint fix were run before commit.