### PR TITLE
Refactor optimistic CRUD through collections

### DIFF
--- a/frontend/src/components/add-project-dialog.tsx
+++ b/frontend/src/components/add-project-dialog.tsx
@@ -3,15 +3,14 @@ import { Loader2, Search, Lock, X, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Project, projectsCollection } from "@/lib/collections";
 import { cn } from "../lib/utils";
 import {
   fetchInstallations,
   fetchInstallationRepos,
-  createProjects,
   type Installation,
   type GitHubRepo,
 } from "../lib/api";
-import { Project } from "@/lib/collections";
 
 interface RepoWithInstallation extends GitHubRepo {
   installationId: number;
@@ -20,12 +19,12 @@ interface RepoWithInstallation extends GitHubRepo {
 export function AddProjectDialog({
   open,
   onClose,
-  onCreated,
+  organizationId,
   existingProjects,
 }: {
   open: boolean;
   onClose: () => void;
-  onCreated: (txid?: number) => Promise<void> | void;
+  organizationId: string | null;
   existingProjects: Project[];
 }) {
   const [installations, setInstallations] = useState<Installation[]>([]);
@@ -80,19 +79,38 @@ export function AddProjectDialog({
   }
 
   async function handleAdd() {
+    if (!organizationId) {
+      setError("No active organization selected.");
+      return;
+    }
+
     setCreating(true);
     setError(null);
     try {
-      const reposList = repos
+      const now = Date.now();
+      const selectedRepos = repos
         .filter((r) => selected.has(r.htmlUrl))
-        .map((r) => ({
-          name: r.fullName,
-          repoUrl: r.htmlUrl,
-          installationId: r.installationId,
-        }));
+        .map((r, index) => {
+          const createdAt = now + index;
+          return {
+            id: crypto.randomUUID(),
+            organization_id: organizationId,
+            created_at: BigInt(createdAt),
+            updated_at: BigInt(createdAt),
+            name: r.fullName,
+            repo_url: r.htmlUrl,
+            installation_id: r.installationId,
+          };
+        });
 
-      const { txid } = await createProjects(reposList);
-      await onCreated(txid);
+      if (selectedRepos.length === 0) {
+        setError("Select at least one repository.");
+        return;
+      }
+
+      const tx = projectsCollection.insert(selectedRepos);
+      await tx.isPersisted.promise;
+
       onClose();
     } catch {
       setError("Failed to create projects.");

--- a/frontend/src/components/layout/task-list.tsx
+++ b/frontend/src/components/layout/task-list.tsx
@@ -12,7 +12,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "../../lib/utils";
-import { createTask, deleteTask } from "../../lib/api";
 import { projectsCollection, tasksCollection } from "../../lib/collections";
 
 export function TaskList() {
@@ -35,10 +34,20 @@ export function TaskList() {
     if (creating || !defaultProject) return;
     setCreating(true);
     try {
-      const { data: task, txid } = await createTask("New task", defaultProject.id);
-      if (txid !== undefined) {
-        await tasksCollection.utils.awaitTxId(txid);
-      }
+      const now = Date.now();
+      const task = {
+        id: crypto.randomUUID(),
+        organization_id: defaultProject.organization_id,
+        project_id: defaultProject.id,
+        title: "New task",
+        status: "open",
+        created_at: BigInt(now),
+        updated_at: BigInt(now),
+      };
+
+      const tx = tasksCollection.insert(task);
+      await tx.isPersisted.promise;
+
       navigate({ to: "/tasks/$taskId", params: { taskId: task.id } });
     } finally {
       setCreating(false);
@@ -68,10 +77,9 @@ export function TaskList() {
     setDeleteError(null);
 
     try {
-      const { txid } = await deleteTask(deletingTaskId);
-      if (txid !== undefined) {
-        await tasksCollection.utils.awaitTxId(txid);
-      }
+      const tx = tasksCollection.delete(deletingTaskId);
+      await tx.isPersisted.promise;
+
       if (isDeletingActiveTask) {
         navigate({ to: "/", replace: true });
       }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -152,8 +152,17 @@ export function fetchInstallationRepos(installationId: number) {
   return fetchJson<GitHubRepo[]>(`/installations/${installationId}/repos`);
 }
 
+export interface CreateProjectInput {
+  id?: string;
+  name: string;
+  repoUrl: string;
+  installationId: number;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
 export function createProjects(
-  repos: Array<{ name: string; repoUrl: string; installationId: number }>,
+  repos: Array<CreateProjectInput>,
 ): Promise<MutationResult<Project[]>> {
   return postJsonWithTx<Project[]>("/projects", { repos });
 }
@@ -205,8 +214,17 @@ export interface TaskRunEvent {
   createdAt: number;
 }
 
-export function createTask(title: string, projectId: string): Promise<MutationResult<Task>> {
-  return postJsonWithTx<Task>("/tasks", { title, projectId });
+export interface CreateTaskInput {
+  id?: string;
+  title: string;
+  projectId: string;
+  status?: string;
+  createdAt?: number;
+  updatedAt?: number;
+}
+
+export function createTask(input: CreateTaskInput): Promise<MutationResult<Task>> {
+  return postJsonWithTx<Task>("/tasks", input);
 }
 
 export function updateTask(taskId: string, title: string): Promise<MutationResult<Task>> {
@@ -219,10 +237,14 @@ export function deleteTask(taskId: string): Promise<{ txid?: number }> {
 
 export function createTaskMessage(
   taskId: string,
-  role: string,
-  content: string,
+  input: {
+    id?: string;
+    role: string;
+    content: string;
+    createdAt?: number;
+  },
 ): Promise<MutationResult<TaskMessage>> {
-  return postJsonWithTx<TaskMessage>(`/tasks/${taskId}/messages`, { role, content });
+  return postJsonWithTx<TaskMessage>(`/tasks/${taskId}/messages`, input);
 }
 
 export function createTaskRun(

--- a/frontend/src/lib/collections.ts
+++ b/frontend/src/lib/collections.ts
@@ -1,6 +1,7 @@
 import { createCollection } from "@tanstack/react-db";
 import { electricCollectionOptions } from "@tanstack/electric-db-collection";
 import { z } from "zod";
+import { createProjects, createTask, createTaskMessage, deleteTask, updateTask } from "./api";
 
 const BASE_URL = globalThis.location?.origin;
 
@@ -33,6 +34,18 @@ const taskMessageSchema = z.object({
   created_at: z.bigint(),
 });
 
+function txidsToMatch(txids: Array<number>) {
+  if (txids.length === 0) {
+    return;
+  }
+
+  if (txids.length === 1) {
+    return { txid: txids[0] };
+  }
+
+  return { txid: txids };
+}
+
 // ---- Projects collection ----
 
 export const projectsCollection = createCollection(
@@ -42,6 +55,35 @@ export const projectsCollection = createCollection(
       url: `${BASE_URL}/api/projects/shape`,
     },
     getKey: (p) => p.id,
+    onInsert: async ({ transaction }) => {
+      const repos = transaction.mutations.map((mutation) => {
+        const project = mutation.modified;
+        if (!project.repo_url) {
+          throw new Error("Project repository URL is required");
+        }
+        if (project.installation_id === null) {
+          throw new Error("Project installation ID is required");
+        }
+
+        return {
+          id: project.id,
+          name: project.name,
+          repoUrl: project.repo_url,
+          installationId: project.installation_id,
+          createdAt: Number(project.created_at),
+          updatedAt: Number(project.updated_at),
+        };
+      });
+
+      const { txid } = await createProjects(repos);
+      return txid !== undefined ? { txid } : undefined;
+    },
+    onUpdate: async () => {
+      throw new Error("Project updates are not supported");
+    },
+    onDelete: async () => {
+      throw new Error("Project deletion is not supported");
+    },
   }),
 );
 
@@ -54,6 +96,60 @@ export const tasksCollection = createCollection(
       url: `${BASE_URL}/api/tasks/shape`,
     },
     getKey: (t) => t.id,
+    onInsert: async ({ transaction }) => {
+      const txids: Array<number> = [];
+
+      for (const mutation of transaction.mutations) {
+        const task = mutation.modified;
+        if (!task.project_id) {
+          throw new Error("Task project is required");
+        }
+
+        const { txid } = await createTask({
+          id: task.id,
+          title: task.title,
+          projectId: task.project_id,
+          status: task.status,
+          createdAt: Number(task.created_at),
+          updatedAt: Number(task.updated_at),
+        });
+
+        if (txid !== undefined) {
+          txids.push(txid);
+        }
+      }
+
+      return txidsToMatch(txids);
+    },
+    onUpdate: async ({ transaction }) => {
+      const txids: Array<number> = [];
+
+      for (const mutation of transaction.mutations) {
+        const title = mutation.modified.title.trim();
+        if (title.length === 0) {
+          throw new Error("Task title cannot be empty");
+        }
+
+        const { txid } = await updateTask(String(mutation.key), title);
+        if (txid !== undefined) {
+          txids.push(txid);
+        }
+      }
+
+      return txidsToMatch(txids);
+    },
+    onDelete: async ({ transaction }) => {
+      const txids: Array<number> = [];
+
+      for (const mutation of transaction.mutations) {
+        const { txid } = await deleteTask(String(mutation.key));
+        if (txid !== undefined) {
+          txids.push(txid);
+        }
+      }
+
+      return txidsToMatch(txids);
+    },
   }),
 );
 
@@ -66,5 +162,30 @@ export const taskMessagesCollection = createCollection(
       url: `${BASE_URL}/api/tasks/messages/shape`,
     },
     getKey: (m) => m.id,
+    onInsert: async ({ transaction }) => {
+      const txids: Array<number> = [];
+
+      for (const mutation of transaction.mutations) {
+        const message = mutation.modified;
+        const { txid } = await createTaskMessage(message.task_id, {
+          id: message.id,
+          role: message.role,
+          content: message.content,
+          createdAt: Number(message.created_at),
+        });
+
+        if (txid !== undefined) {
+          txids.push(txid);
+        }
+      }
+
+      return txidsToMatch(txids);
+    },
+    onUpdate: async () => {
+      throw new Error("Task message updates are not supported");
+    },
+    onDelete: async () => {
+      throw new Error("Task message deletion is not supported");
+    },
   }),
 );

--- a/frontend/src/pages/settings-page.tsx
+++ b/frontend/src/pages/settings-page.tsx
@@ -13,6 +13,7 @@ import {
   type ProviderOauthStart,
 } from "../lib/api";
 import { AddProjectDialog } from "../components/add-project-dialog";
+import { useOrganization } from "../components/layout/use-organization";
 import { projectsCollection } from "../lib/collections";
 
 const OPENAI_PROVIDER = "openai";
@@ -25,6 +26,7 @@ export function SettingsPage() {
   const { data: projects, isLoading } = useLiveQuery((q) =>
     q.from({ p: projectsCollection }).orderBy(({ p }) => p.created_at, "asc"),
   );
+  const activeOrganization = useOrganization();
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [openaiApiKey, setOpenaiApiKey] = useState("");
@@ -36,12 +38,6 @@ export function SettingsPage() {
   const [completingOauth, setCompletingOauth] = useState(false);
   const [oauthAttempt, setOauthAttempt] = useState<ProviderOauthStart | null>(null);
   const [providerError, setProviderError] = useState<string | null>(null);
-
-  async function handleCreated(txid?: number) {
-    if (txid !== undefined) {
-      await projectsCollection.utils.awaitTxId(txid);
-    }
-  }
 
   useEffect(() => {
     void loadOpenAiStatus();
@@ -287,7 +283,7 @@ export function SettingsPage() {
       <AddProjectDialog
         open={dialogOpen}
         onClose={() => setDialogOpen(false)}
-        onCreated={handleCreated}
+        organizationId={activeOrganization.data?.id ?? null}
         existingProjects={projects}
       />
     </div>

--- a/frontend/src/pages/task-page.tsx
+++ b/frontend/src/pages/task-page.tsx
@@ -6,14 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import {
-  createTaskMessage,
-  createTaskRun,
-  fetchTaskRun,
-  fetchTaskRunEvents,
-  updateTask,
-  type TaskRunEvent,
-} from "../lib/api";
+import { createTaskRun, fetchTaskRun, fetchTaskRunEvents, type TaskRunEvent } from "../lib/api";
 import { taskMessagesCollection, tasksCollection } from "../lib/collections";
 
 const RUN_TERMINAL_STATUSES = new Set(["succeeded", "failed"]);
@@ -99,14 +92,15 @@ export function TaskPage() {
     setRunSandboxId(null);
 
     try {
-      const { data: userMessage, txid: messageTxid } = await createTaskMessage(
-        taskId,
-        "user",
+      const userMessage = {
+        id: crypto.randomUUID(),
+        task_id: taskId,
+        role: "user",
         content,
-      );
-      if (messageTxid !== undefined) {
-        await taskMessagesCollection.utils.awaitTxId(messageTxid);
-      }
+        created_at: BigInt(Date.now()),
+      };
+      const messageTx = taskMessagesCollection.insert(userMessage);
+      await messageTx.isPersisted.promise;
 
       const run = await createTaskRun(taskId, userMessage.id);
       setActiveRunId(run.id);
@@ -200,10 +194,12 @@ export function TaskPage() {
     setTitleError(null);
 
     try {
-      const { txid } = await updateTask(taskId, nextTitle);
-      if (txid !== undefined) {
-        await tasksCollection.utils.awaitTxId(txid);
-      }
+      const tx = tasksCollection.update(taskId, (draft) => {
+        draft.title = nextTitle;
+        draft.updated_at = BigInt(Date.now());
+      });
+      await tx.isPersisted.promise;
+
       setEditingTitle(false);
     } catch (error) {
       setTitleError(error instanceof Error ? error.message : "Failed to update task title");

--- a/worker/src/routes/projects.ts
+++ b/worker/src/routes/projects.ts
@@ -23,6 +23,27 @@ function getOrgId(c: { get: (key: "session") => Env["Variables"]["session"] }): 
   return (session.session as { activeOrganizationId?: string | null }).activeOrganizationId ?? null;
 }
 
+function parseOptionalId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseOptionalTimestamp(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  if (value < 0) {
+    return undefined;
+  }
+
+  return Math.trunc(value);
+}
+
 projects.get("/shape", async (c) => {
   const orgId = getOrgId(c);
 
@@ -47,7 +68,14 @@ projects.post("/", async (c) => {
   }
 
   let body: {
-    repos: Array<{ name: string; repoUrl: string; installationId: number }>;
+    repos: Array<{
+      id?: string;
+      name: string;
+      repoUrl: string;
+      installationId: number;
+      createdAt?: number;
+      updatedAt?: number;
+    }>;
   };
   try {
     body = await c.req.json();
@@ -60,7 +88,7 @@ projects.post("/", async (c) => {
   }
 
   for (const repo of body.repos) {
-    if (!repo.name || !repo.repoUrl || !repo.installationId) {
+    if (!repo.name || !repo.repoUrl || typeof repo.installationId !== "number") {
       return c.json({ error: "Each repo must have name, repoUrl, and installationId" }, 400);
     }
   }
@@ -83,15 +111,20 @@ projects.post("/", async (c) => {
     }
 
     const now = Date.now();
-    const created = newRepos.map((repo) => ({
-      id: crypto.randomUUID(),
-      organizationId: orgId,
-      name: repo.name,
-      repoUrl: repo.repoUrl,
-      installationId: repo.installationId,
-      createdAt: now,
-      updatedAt: now,
-    }));
+    const created = newRepos.map((repo) => {
+      const createdAt = parseOptionalTimestamp(repo.createdAt) ?? now;
+      const updatedAt = parseOptionalTimestamp(repo.updatedAt) ?? createdAt;
+
+      return {
+        id: parseOptionalId(repo.id) ?? crypto.randomUUID(),
+        organizationId: orgId,
+        name: repo.name,
+        repoUrl: repo.repoUrl,
+        installationId: repo.installationId,
+        createdAt,
+        updatedAt,
+      };
+    });
 
     await tx.insert(schema.projects).values(created);
     return { created, txid };

--- a/worker/src/routes/tasks.ts
+++ b/worker/src/routes/tasks.ts
@@ -42,6 +42,27 @@ function getUserId(c: { get: (key: "session") => Env["Variables"]["session"] }):
   return c.get("session").user.id;
 }
 
+function parseOptionalId(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseOptionalTimestamp(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  if (value < 0) {
+    return undefined;
+  }
+
+  return Math.trunc(value);
+}
+
 async function getTaskForOrg(
   db: AppDb,
   taskId: string,
@@ -79,19 +100,14 @@ async function ensureRunForOrg(
   return run;
 }
 
-async function getNextTaskMessageTimestamp(db: AppDb, taskId: string): Promise<number> {
-  const now = Date.now();
+async function getLatestTaskMessageTimestamp(db: AppDb, taskId: string): Promise<number | null> {
   const latest = await db.query.taskMessages.findFirst({
     where: eq(schema.taskMessages.taskId, taskId),
     columns: { createdAt: true },
     orderBy: desc(schema.taskMessages.createdAt),
   });
 
-  if (!latest?.createdAt) {
-    return now;
-  }
-
-  return latest.createdAt >= now ? latest.createdAt + 1 : now;
+  return latest?.createdAt ?? null;
 }
 
 tasks.get("/shape", async (c) => {
@@ -117,7 +133,14 @@ tasks.post("/", async (c) => {
     return c.json({ error: "No active organization" }, 400);
   }
 
-  let body: { title: string; projectId: string };
+  let body: {
+    id?: string;
+    title: string;
+    projectId: string;
+    status?: string;
+    createdAt?: number;
+    updatedAt?: number;
+  };
   try {
     body = await c.req.json();
   } catch {
@@ -143,14 +166,20 @@ tasks.post("/", async (c) => {
 
   const result = await withTransaction(db, async (tx, txid) => {
     const now = Date.now();
+    const createdAt = parseOptionalTimestamp(body.createdAt) ?? now;
+    const updatedAt = parseOptionalTimestamp(body.updatedAt) ?? createdAt;
+    const status =
+      typeof body.status === "string" && body.status.trim().length > 0
+        ? body.status.trim()
+        : "open";
     const task = {
-      id: crypto.randomUUID(),
+      id: parseOptionalId(body.id) ?? crypto.randomUUID(),
       organizationId: orgId,
       projectId: body.projectId,
       title: body.title.trim(),
-      status: "open",
-      createdAt: now,
-      updatedAt: now,
+      status,
+      createdAt,
+      updatedAt,
     };
 
     await tx.insert(schema.tasks).values(task);
@@ -289,7 +318,7 @@ tasks.post("/:taskId/messages", async (c) => {
     return c.json({ error: "Task not found" }, 404);
   }
 
-  let body: { role: string; content: string };
+  let body: { id?: string; role: string; content: string; createdAt?: number };
   try {
     body = await c.req.json();
   } catch {
@@ -305,20 +334,26 @@ tasks.post("/:taskId/messages", async (c) => {
   }
 
   const result = await withTransaction(db, async (tx, txid) => {
-    const now = await getNextTaskMessageTimestamp(tx as unknown as AppDb, taskId);
+    const requestedCreatedAt = parseOptionalTimestamp(body.createdAt) ?? Date.now();
+    const latestCreatedAt = await getLatestTaskMessageTimestamp(tx as unknown as AppDb, taskId);
+    const createdAt =
+      latestCreatedAt !== null && latestCreatedAt >= requestedCreatedAt
+        ? latestCreatedAt + 1
+        : requestedCreatedAt;
+
     const message = {
-      id: crypto.randomUUID(),
+      id: parseOptionalId(body.id) ?? crypto.randomUUID(),
       organizationId: orgId,
       taskId,
       role: body.role,
       content: body.content.trim(),
-      createdAt: now,
+      createdAt,
     };
 
     await tx.insert(schema.taskMessages).values(message);
 
     // Update task's updatedAt
-    await tx.update(schema.tasks).set({ updatedAt: now }).where(eq(schema.tasks.id, taskId));
+    await tx.update(schema.tasks).set({ updatedAt: createdAt }).where(eq(schema.tasks.id, taskId));
 
     return { message, txid };
   });


### PR DESCRIPTION
This refactor adds collection-level create/update/delete handlers for tasks, projects, and task messages so optimistic writes go through TanStack collections instead of manual API calls. It updates task creation/deletion, task title edits, message sends, and project creation flows to use collection mutations and transaction persistence. It also extends task and project create endpoints to accept client-provided ids/timestamps so optimistic rows reconcile without key churn. Validation run: bun run format, bun run lint:fix, and bun run build.