### PR TITLE
fix(worker): deny external directory access in OpenCode

### DIFF
--- a/worker/src/lib/sandbox.ts
+++ b/worker/src/lib/sandbox.ts
@@ -26,10 +26,18 @@ export async function getOpenCodeClient(
   options?: { restartServer?: boolean },
 ) {
   const restartServer = options?.restartServer ?? true;
+  const mergedConfig: Config = {
+    ...config,
+    permission: {
+      ...config?.permission,
+      external_directory: "deny",
+    },
+  };
+
   if (restartServer) {
     await restartOpenCodeServer(sandbox);
   }
-  return createOpencode<OpencodeClient>(sandbox, { directory, config });
+  return createOpencode<OpencodeClient>(sandbox, { directory, config: mergedConfig });
 }
 
 async function restartOpenCodeServer(sandbox: Sandbox): Promise<void> {


### PR DESCRIPTION
This PR hardens OpenCode sandbox usage by denying external directory access while preserving existing config overrides. It applies a default permission policy in getOpenCodeClient so task runs stay scoped to the configured repository directory. Validation: bun run format and bun run lint:fix.