### PR TITLE
Show task project names in UI

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 worker/migrations/
 worker/migrations-postgres/
+frontend/src/routeTree.gen.ts

--- a/frontend/src/components/layout/task-list.tsx
+++ b/frontend/src/components/layout/task-list.tsx
@@ -29,6 +29,7 @@ export function TaskList() {
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const [defaultProject] = projects;
+  const projectsById = new Map(projects.map((project) => [project.id, project]));
 
   async function handleNewTask() {
     if (creating || !defaultProject) return;
@@ -126,6 +127,7 @@ export function TaskList() {
         ) : (
           tasks.map((task) => {
             const isActive = pathname === `/tasks/${task.id}`;
+            const projectName = task.project_id ? projectsById.get(task.project_id)?.name : null;
             return (
               <div
                 key={task.id}
@@ -139,10 +141,22 @@ export function TaskList() {
                 <Link
                   to="/tasks/$taskId"
                   params={{ taskId: task.id }}
-                  className="flex min-w-0 flex-1 items-center gap-2 px-2.5 py-2 text-sm"
+                  className="flex min-w-0 flex-1 items-start gap-2 px-2.5 py-2 text-sm"
                 >
-                  <MessageSquare className="w-3.5 h-3.5 shrink-0" />
-                  <span className="truncate">{task.title}</span>
+                  <MessageSquare className="mt-0.5 w-3.5 h-3.5 shrink-0" />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate">{task.title}</p>
+                    {projectName ? (
+                      <p
+                        className={cn(
+                          "truncate text-[11px]",
+                          isActive ? "text-accent-foreground/80" : "text-muted-foreground",
+                        )}
+                      >
+                        {projectName}
+                      </p>
+                    ) : null}
+                  </div>
                 </Link>
                 <Button
                   type="button"

--- a/frontend/src/pages/task-page.tsx
+++ b/frontend/src/pages/task-page.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { createTaskRun, fetchTaskRun, fetchTaskRunEvents, type TaskRunEvent } from "../lib/api";
-import { taskMessagesCollection, tasksCollection } from "../lib/collections";
+import { projectsCollection, taskMessagesCollection, tasksCollection } from "../lib/collections";
 
 const RUN_TERMINAL_STATUSES = new Set(["succeeded", "failed"]);
 
@@ -30,7 +30,11 @@ export function TaskPage() {
   const mountedRef = useRef(true);
 
   const { data: tasks } = useLiveQuery((q) => q.from({ t: tasksCollection }));
+  const { data: projects } = useLiveQuery((q) => q.from({ p: projectsCollection }));
   const task = tasks?.find((t) => t.id === taskId);
+  const taskProject = task?.project_id
+    ? projects.find((project) => project.id === task.project_id)
+    : null;
 
   const { data: messages, isLoading } = useLiveQuery(
     (q) =>
@@ -269,18 +273,23 @@ export function TaskPage() {
             </Button>
           </div>
         ) : (
-          <div className="flex min-h-8 min-w-0 items-center gap-2">
-            <h2 className="m-0 truncate text-sm font-medium">{task?.title ?? "Task"}</h2>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              onClick={handleTitleEditStart}
-              className="text-muted-foreground"
-              title="Edit task name"
-            >
-              <Pencil className="h-3.5 w-3.5" />
-            </Button>
+          <div className="min-w-0">
+            <div className="flex min-h-8 min-w-0 items-center gap-2">
+              <h2 className="m-0 truncate text-sm font-medium">{task?.title ?? "Task"}</h2>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                onClick={handleTitleEditStart}
+                className="text-muted-foreground"
+                title="Edit task name"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+            {taskProject ? (
+              <p className="truncate text-xs text-muted-foreground">{taskProject.name}</p>
+            ) : null}
           </div>
         )}
         {titleError ? <p className="mt-1 text-xs text-destructive">{titleError}</p> : null}


### PR DESCRIPTION
## Summary
- show each task's project name in the sidebar task list
- show the active task's project name in the task header
- ignore frontend/src/routeTree.gen.ts in formatter so generated files do not churn

## Validation
- bun run format
- bun run lint:fix
- bun run build