### PR TITLE
Show task status as spinner in sidebar

### DIFF
--- a/frontend/src/components/layout/task-list.tsx
+++ b/frontend/src/components/layout/task-list.tsx
@@ -142,7 +142,11 @@ export function TaskList() {
                   params={{ taskId: task.id }}
                   className="flex min-w-0 flex-1 items-start gap-2 px-2.5 py-2 text-sm"
                 >
-                  <MessageSquare className="mt-0.5 w-3.5 h-3.5 shrink-0" />
+                  {task.status === "running" ? (
+                    <Loader2 className="mt-0.5 w-3.5 h-3.5 shrink-0 animate-spin" />
+                  ) : (
+                    <MessageSquare className="mt-0.5 w-3.5 h-3.5 shrink-0" />
+                  )}
                   <div className="min-w-0 flex-1">
                     <p className="truncate">{task.title}</p>
                     {projectName ? (

--- a/worker/src/lib/task-runs.ts
+++ b/worker/src/lib/task-runs.ts
@@ -233,7 +233,10 @@ export async function executeTaskRun(args: {
       })
       .where(eq(schema.taskRuns.id, runId));
 
-    await db.update(schema.tasks).set({ updatedAt: finishedAt }).where(eq(schema.tasks.id, taskId));
+    await db
+      .update(schema.tasks)
+      .set({ status: "open", updatedAt: finishedAt })
+      .where(eq(schema.tasks.id, taskId));
   } catch (error) {
     await markRunFailed({
       db,
@@ -772,6 +775,9 @@ async function markRunFailed(args: {
   } catch {}
 
   try {
-    await db.update(schema.tasks).set({ updatedAt: finishedAt }).where(eq(schema.tasks.id, taskId));
+    await db
+      .update(schema.tasks)
+      .set({ status: "open", updatedAt: finishedAt })
+      .where(eq(schema.tasks.id, taskId));
   } catch {}
 }

--- a/worker/src/routes/tasks.ts
+++ b/worker/src/routes/tasks.ts
@@ -555,6 +555,10 @@ tasks.post("/:taskId/runs", async (c) => {
     };
 
     await db.insert(schema.taskRuns).values(run);
+    await db
+      .update(schema.tasks)
+      .set({ status: "running", updatedAt: now })
+      .where(eq(schema.tasks.id, taskId));
 
     const project = task.projectId
       ? await db.query.projects.findFirst({


### PR DESCRIPTION
When a task run starts, the task status is set to 'running' on the backend. The sidebar now displays a spinning Loader2 icon instead of the chat icon when the task status is 'running', providing visual feedback that the task is in progress.

## Changes
- Backend: Set task status to 'running' when a run starts, reset to 'open' when finished
- Frontend: Show spinner icon instead of chat icon when task status is 'running'