### PR TITLE
feat: switch task event streaming to durable-streams client

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "clanki",
       "dependencies": {
         "@cloudflare/sandbox": "^0.7.2",
+        "@durable-streams/client": "^0.2.1",
         "@electric-sql/client": "^1.5.4",
         "@octokit/webhooks": "^14.2.0",
         "@opencode-ai/sdk": "^1.2.1",
@@ -180,6 +181,8 @@
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.52.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@durable-streams/client": ["@durable-streams/client@0.2.1", "", { "dependencies": { "@microsoft/fetch-event-source": "^2.0.1", "fastq": "^1.19.1" } }, "sha512-+mGdK6TuDR9fJPo8jw6DufPfoUv6g+27xoPES76GXQc6y3val9Oe/SK2o2FV9sqqLSE19HEUSxTp0D6CZebfZw=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -270,9 +270,8 @@ export function fetchTaskRuns(taskId: string) {
   return fetchJson<TaskRun[]>(`/tasks/${taskId}/runs`);
 }
 
-export function getTaskEventStreamUrl(taskId: string, offset: string) {
-  const params = new URLSearchParams({ offset });
-  return `${BASE}/tasks/${taskId}/stream?${params.toString()}`;
+export function getTaskEventStreamUrl(taskId: string) {
+  return `${globalThis.location.origin}/api/tasks/${taskId}/stream`;
 }
 
 // ---- Provider settings ----

--- a/frontend/src/pages/task-page.tsx
+++ b/frontend/src/pages/task-page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useLiveQuery, eq } from "@tanstack/react-db";
 import { useParams } from "@tanstack/react-router";
+import { stream } from "@durable-streams/client";
 import { Check, Loader2, Pencil, Send, X } from "lucide-react";
 import {
   TaskStreamActivity,
@@ -141,14 +142,8 @@ export function TaskPage() {
       return;
     }
 
-    let cancelled = false;
-    let reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
-    let source: EventSource | null = null;
-    let reconnectDelayMs = 500;
-    let resetOffsetAttempted = false;
+    const abortController = new AbortController();
     const seenEventIds = new Set<string>();
-    const offsetStorageKey = getTaskStreamOffsetStorageKey(taskId);
-    let currentOffset = "-1";
 
     const applyEvent = (event: TaskStreamEvent) => {
       if (seenEventIds.has(event.id)) {
@@ -180,72 +175,24 @@ export function TaskPage() {
       }
     };
 
-    const open = (offset: string) => {
-      currentOffset = offset;
-      const streamUrl = getTaskEventStreamUrl(taskId, offset);
-      source = new EventSource(streamUrl, { withCredentials: true });
+    const streamUrl = getTaskEventStreamUrl(taskId);
 
-      source.addEventListener("data", (rawEvent) => {
-        const events = parseTaskStreamDataEvent((rawEvent as MessageEvent).data);
-        if (events.length === 0) {
-          return;
-        }
-
-        reconnectDelayMs = 500;
-        resetOffsetAttempted = false;
-        for (const event of events) {
-          if (cancelled) {
-            return;
-          }
+    stream<TaskStreamEvent>({
+      url: streamUrl,
+      offset: "-1",
+      live: "sse",
+      json: true,
+      signal: abortController.signal,
+    }).then((res) => {
+      res.subscribeJson(({ items }) => {
+        for (const event of items) {
           applyEvent(event);
         }
       });
-
-      source.addEventListener("control", (rawEvent) => {
-        const control = parseTaskStreamControlEvent((rawEvent as MessageEvent).data);
-        if (!control) {
-          return;
-        }
-
-        if (typeof control.streamNextOffset === "string" && control.streamNextOffset.length > 0) {
-          currentOffset = control.streamNextOffset;
-          storeTaskStreamOffset(offsetStorageKey, control.streamNextOffset);
-          resetOffsetAttempted = false;
-        }
-      });
-
-      source.addEventListener("error", () => {
-        source?.close();
-        if (cancelled) {
-          return;
-        }
-
-        let nextOffset = currentOffset;
-        if (!resetOffsetAttempted && nextOffset !== "-1") {
-          nextOffset = "-1";
-          currentOffset = "-1";
-          resetOffsetAttempted = true;
-          clearTaskStreamOffset(offsetStorageKey);
-        }
-        const delay = reconnectDelayMs;
-        reconnectDelayMs = Math.min(reconnectDelayMs * 2, 8000);
-        reconnectTimeout = setTimeout(() => {
-          if (!cancelled) {
-            open(nextOffset);
-          }
-        }, delay);
-      });
-    };
-
-    clearTaskStreamOffset(offsetStorageKey);
-    open("-1");
+    });
 
     return () => {
-      cancelled = true;
-      source?.close();
-      if (reconnectTimeout) {
-        clearTimeout(reconnectTimeout);
-      }
+      abortController.abort();
     };
   }, [taskId]);
 
@@ -511,99 +458,6 @@ export function TaskPage() {
       </div>
     </div>
   );
-}
-
-function getTaskStreamOffsetStorageKey(taskId: string): string {
-  return `task-stream-offset:${taskId}`;
-}
-
-function storeTaskStreamOffset(key: string, offset: string): void {
-  try {
-    sessionStorage.setItem(key, offset);
-  } catch {}
-}
-
-function clearTaskStreamOffset(key: string): void {
-  try {
-    sessionStorage.removeItem(key);
-  } catch {}
-}
-
-function parseTaskStreamDataEvent(raw: unknown): TaskStreamEvent[] {
-  if (typeof raw !== "string" || raw.trim().length === 0) {
-    return [];
-  }
-
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (Array.isArray(parsed)) {
-      return parsed
-        .map(toTaskStreamEvent)
-        .filter((event): event is TaskStreamEvent => event !== null);
-    }
-
-    const single = toTaskStreamEvent(parsed);
-    return single ? [single] : [];
-  } catch {
-    return [];
-  }
-}
-
-function toTaskStreamEvent(value: unknown): TaskStreamEvent | null {
-  const record = toRecord(value);
-  if (!record) {
-    return null;
-  }
-
-  const id = toStringOrNull(record.id);
-  const taskId = toStringOrNull(record.taskId);
-  const runId = toStringOrNull(record.runId);
-  const kind = toStringOrNull(record.kind);
-  const payload = toStringOrNull(record.payload);
-  const createdAt = record.createdAt;
-  if (
-    !id ||
-    !taskId ||
-    !runId ||
-    !kind ||
-    payload === null ||
-    typeof createdAt !== "number" ||
-    !Number.isFinite(createdAt)
-  ) {
-    return null;
-  }
-
-  return {
-    id,
-    taskId,
-    runId,
-    kind,
-    payload,
-    createdAt,
-  };
-}
-
-function parseTaskStreamControlEvent(
-  raw: unknown,
-): { streamNextOffset?: string; upToDate?: boolean; streamClosed?: boolean } | null {
-  if (typeof raw !== "string" || raw.trim().length === 0) {
-    return null;
-  }
-
-  try {
-    const record = toRecord(JSON.parse(raw));
-    if (!record) {
-      return null;
-    }
-
-    return {
-      streamNextOffset: toStringOrNull(record.streamNextOffset) ?? undefined,
-      upToDate: typeof record.upToDate === "boolean" ? record.upToDate : undefined,
-      streamClosed: typeof record.streamClosed === "boolean" ? record.streamClosed : undefined,
-    };
-  } catch {
-    return null;
-  }
 }
 
 type AssistantMessageSnapshot = {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@cloudflare/sandbox": "^0.7.2",
+    "@durable-streams/client": "^0.2.1",
     "@electric-sql/client": "^1.5.4",
     "@octokit/webhooks": "^14.2.0",
     "@opencode-ai/sdk": "^1.2.1",

--- a/worker/src/lib/durable-streams.ts
+++ b/worker/src/lib/durable-streams.ts
@@ -1,3 +1,5 @@
+import { DurableStream, DurableStreamError } from "@durable-streams/client";
+
 export type DurableStreamsEnv = {
   DURABLE_STREAMS_SERVICE_ID?: string;
   DURABLE_STREAMS_SECRET?: string;
@@ -13,7 +15,6 @@ export interface TaskEventStreamMessage {
 }
 
 const DURABLE_STREAMS_BASE_URL = "https://api.electric-sql.cloud";
-const TASK_EVENTS_CONTENT_TYPE = "application/json";
 
 function isDurableStreamsConfigured(env: DurableStreamsEnv): boolean {
   return (
@@ -24,9 +25,47 @@ function isDurableStreamsConfigured(env: DurableStreamsEnv): boolean {
   );
 }
 
+function buildStreamUrl(env: DurableStreamsEnv, streamPath: string): string {
+  const serviceId = env.DURABLE_STREAMS_SERVICE_ID?.trim();
+  if (!serviceId) {
+    throw new Error("Missing DURABLE_STREAMS_SERVICE_ID");
+  }
+
+  const encodedPath = streamPath
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  return `${DURABLE_STREAMS_BASE_URL}/v1/stream/${encodeURIComponent(serviceId)}/${encodedPath}`;
+}
+
+function buildHeaders(env: DurableStreamsEnv): Record<string, string> {
+  const secret = env.DURABLE_STREAMS_SECRET?.trim();
+  if (!secret) {
+    throw new Error("Missing DURABLE_STREAMS_SECRET");
+  }
+  return { Authorization: `Bearer ${secret}` };
+}
+
 function buildTaskEventsStreamPath(args: { organizationId: string; taskId: string }): string {
-  const { organizationId, taskId } = args;
-  return `org/${organizationId}/tasks/${taskId}/events`;
+  return `org/${args.organizationId}/tasks/${args.taskId}/events`;
+}
+
+async function ensureStream(env: DurableStreamsEnv, url: string): Promise<boolean> {
+  const headers = buildHeaders(env);
+  try {
+    await DurableStream.create({ url, headers, contentType: "application/json" });
+    return true;
+  } catch (error) {
+    if (error instanceof DurableStreamError && error.code === "CONFLICT_EXISTS") {
+      return true;
+    }
+    console.warn("Failed to ensure durable stream", {
+      url,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
 }
 
 export async function appendTaskEventToDurableStream(args: {
@@ -42,30 +81,25 @@ export async function appendTaskEventToDurableStream(args: {
   }
 
   const streamPath = buildTaskEventsStreamPath({ organizationId, taskId });
-  const streamUrl = buildDurableStreamUrl(env, streamPath);
+  const url = buildStreamUrl(env, streamPath);
 
-  const ensured = await ensureDurableStream(env, streamUrl);
+  const ensured = await ensureStream(env, url);
   if (!ensured) {
     return;
   }
 
-  const appendResponse = await fetch(streamUrl.toString(), {
-    method: "POST",
-    headers: {
-      Authorization: buildAuthorizationHeader(env),
-      "Content-Type": TASK_EVENTS_CONTENT_TYPE,
-    },
-    body: JSON.stringify(event),
-  });
-
-  if (!appendResponse.ok) {
-    const details = (await appendResponse.text()).trim();
+  try {
+    const handle = new DurableStream({
+      url,
+      headers: buildHeaders(env),
+      batching: false,
+    });
+    await handle.append(JSON.stringify(event));
+  } catch (error) {
     console.warn("Failed to append task event to durable stream", {
       organizationId,
       taskId,
-      status: appendResponse.status,
-      statusText: appendResponse.statusText,
-      details,
+      message: error instanceof Error ? error.message : String(error),
     });
   }
 }
@@ -83,70 +117,20 @@ export async function openTaskEventsSse(args: {
   }
 
   const streamPath = buildTaskEventsStreamPath({ organizationId, taskId });
-  const streamUrl = buildDurableStreamUrl(env, streamPath);
+  const url = buildStreamUrl(env, streamPath);
 
-  // Ensure stream exists so first subscribers don't get 404 before the first run event.
-  await ensureDurableStream(env, streamUrl);
+  await ensureStream(env, url);
 
-  const readUrl = new URL(streamUrl);
+  const readUrl = new URL(url);
   readUrl.searchParams.set("offset", offset);
   readUrl.searchParams.set("live", "sse");
 
   return fetch(readUrl.toString(), {
     method: "GET",
     headers: {
-      Authorization: buildAuthorizationHeader(env),
+      ...buildHeaders(env),
       Accept: "text/event-stream",
       "Cache-Control": "no-cache",
     },
   });
-}
-
-function buildDurableStreamUrl(env: DurableStreamsEnv, streamPath: string): URL {
-  const serviceId = env.DURABLE_STREAMS_SERVICE_ID?.trim();
-  if (!serviceId) {
-    throw new Error("Missing DURABLE_STREAMS_SERVICE_ID");
-  }
-
-  const encodedPath = streamPath
-    .split("/")
-    .map((segment) => encodeURIComponent(segment))
-    .join("/");
-
-  return new URL(
-    `/v1/stream/${encodeURIComponent(serviceId)}/${encodedPath}`,
-    DURABLE_STREAMS_BASE_URL,
-  );
-}
-
-function buildAuthorizationHeader(env: DurableStreamsEnv): string {
-  const secret = env.DURABLE_STREAMS_SECRET?.trim();
-  if (!secret) {
-    throw new Error("Missing DURABLE_STREAMS_SECRET");
-  }
-
-  return `Bearer ${secret}`;
-}
-
-async function ensureDurableStream(env: DurableStreamsEnv, streamUrl: URL): Promise<boolean> {
-  const response = await fetch(streamUrl.toString(), {
-    method: "PUT",
-    headers: {
-      Authorization: buildAuthorizationHeader(env),
-      "Content-Type": TASK_EVENTS_CONTENT_TYPE,
-    },
-  });
-
-  if (response.status === 200 || response.status === 201) {
-    return true;
-  }
-
-  const details = (await response.text()).trim();
-  console.warn("Failed to ensure durable stream", {
-    url: streamUrl.toString(),
-    status: response.status,
-    statusText: response.statusText,
-    details,
-  });
-  return false;
 }

--- a/worker/src/routes/tasks.ts
+++ b/worker/src/routes/tasks.ts
@@ -448,14 +448,13 @@ tasks.get("/:taskId/stream", async (c) => {
       );
     }
 
-    const headers = new Headers();
-    headers.set("Content-Type", upstream.headers.get("content-type") ?? "text/event-stream");
-    headers.set("Cache-Control", "no-cache, no-transform");
-    headers.set("Connection", "keep-alive");
-
     return new Response(upstream.body, {
       status: 200,
-      headers,
+      headers: {
+        "Content-Type": upstream.headers.get("content-type") ?? "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+      },
     });
   } catch (error) {
     return c.json(


### PR DESCRIPTION
This switches task event streaming to @durable-streams/client across the worker and frontend. The worker now uses DurableStream.create/append and keeps SSE passthrough for /api/tasks/:taskId/stream. The frontend now consumes the stream with stream(..., live: "sse", json: true) and removes custom EventSource parsing/reconnect code. Validation: bun run format, bun run lint:fix, and bun run build.