### PR TITLE
Fix sandbox startup and git identity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM docker.io/cloudflare/sandbox:0.7.2-opencode
 
 USER root
 
+# Cloudflare sandbox runtime expects a "user" account to exist.
+RUN id -u user >/dev/null 2>&1 || useradd --create-home --home-dir /home/user --shell /bin/bash user
+
 RUN if command -v apt-get >/dev/null 2>&1; then \
       apt-get update && apt-get install -y --no-install-recommends gh && rm -rf /var/lib/apt/lists/*; \
     elif command -v apk >/dev/null 2>&1; then \
@@ -11,9 +14,8 @@ RUN if command -v apt-get >/dev/null 2>&1; then \
       exit 1; \
     fi
 
-USER user
-
 WORKDIR /home/user
+USER user
 
 # Required for wrangler dev (port 3000 is reserved by the internal Bun server)
 EXPOSE 4096

--- a/worker/src/lib/task-execution.ts
+++ b/worker/src/lib/task-execution.ts
@@ -42,6 +42,8 @@ export async function executeTaskPrompt(args: {
   installationId: number | null;
   setupCommand: string | null;
   initiatedByUserId: string;
+  initiatedByUserName: string;
+  initiatedByUserEmail: string;
   provider: SupportedOpencodeProvider;
   model: string;
 }): Promise<void> {
@@ -57,6 +59,8 @@ export async function executeTaskPrompt(args: {
     installationId,
     setupCommand,
     initiatedByUserId,
+    initiatedByUserName,
+    initiatedByUserEmail,
     provider,
     model,
   } = args;
@@ -77,6 +81,29 @@ export async function executeTaskPrompt(args: {
       gitToken = await createInstallationToken(env, installationId);
       // Expose the token so OpenCode can use `gh` CLI for PRs, issues, etc.
       await sandbox.setEnvVars({ GITHUB_TOKEN: gitToken });
+    }
+
+    const gitIdentity = resolveGitIdentity({
+      userId: initiatedByUserId,
+      userName: initiatedByUserName,
+      userEmail: initiatedByUserEmail,
+    });
+    const gitConfigResult = await sandbox.exec(
+      [
+        `git config --global user.name ${shellQuote(gitIdentity.name)}`,
+        `git config --global user.email ${shellQuote(gitIdentity.email)}`,
+      ].join(" && "),
+    );
+    if (!gitConfigResult.success) {
+      throw new Error(
+        formatGitConfigFailure({
+          name: gitIdentity.name,
+          email: gitIdentity.email,
+          exitCode: gitConfigResult.exitCode,
+          stdout: gitConfigResult.stdout,
+          stderr: gitConfigResult.stderr,
+        }),
+      );
     }
 
     // Clone repo on first use (gitCheckout is a no-op if dir already exists on a warm sandbox)
@@ -264,6 +291,41 @@ function formatSetupCommandFailure(args: {
   }
 
   return `Project setup command failed (exit code ${args.exitCode}): ${args.command}\n${output}`;
+}
+
+function resolveGitIdentity(args: { userId: string; userName: string; userEmail: string }): {
+  name: string;
+  email: string;
+} {
+  const name = args.userName.trim().length > 0 ? args.userName.trim() : "Clanki User";
+  const email =
+    args.userEmail.trim().length > 0
+      ? args.userEmail.trim()
+      : `user+${args.userId.slice(0, 12)}@users.noreply.github.com`;
+  return { name, email };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function formatGitConfigFailure(args: {
+  name: string;
+  email: string;
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}): string {
+  const stdout = truncateCommandOutput(args.stdout.trim());
+  const stderr = truncateCommandOutput(args.stderr.trim());
+  const output = [stderr, stdout].filter((part) => part.length > 0).join("\n\n");
+  const base = `Failed to configure git identity (${args.name} <${args.email}>) (exit code ${args.exitCode})`;
+
+  if (output.length === 0) {
+    return base;
+  }
+
+  return `${base}\n${output}`;
 }
 
 async function streamSessionEvents(args: {

--- a/worker/src/orpc/router/tasks.ts
+++ b/worker/src/orpc/router/tasks.ts
@@ -320,6 +320,8 @@ export const tasksRouter = {
           setupCommand: project.setupCommand ?? null,
           prompt: inputMessage.content,
           initiatedByUserId: userId,
+          initiatedByUserName: context.session.user.name,
+          initiatedByUserEmail: context.session.user.email,
           organizationId: orgId,
           provider: providerInput,
           model,

--- a/worker/src/routes/tasks.ts
+++ b/worker/src/routes/tasks.ts
@@ -407,6 +407,7 @@ tasks.post("/:taskId/prompt", async (c) => {
   const { taskId } = c.req.param();
   const orgId = getOrgId(c);
   const userId = getUserId(c);
+  const sessionUser = c.get("session").user;
 
   try {
     if (!orgId) {
@@ -504,6 +505,8 @@ tasks.post("/:taskId/prompt", async (c) => {
         installationId: project.installationId ?? null,
         setupCommand: project.setupCommand ?? null,
         initiatedByUserId: userId,
+        initiatedByUserName: sessionUser.name,
+        initiatedByUserEmail: sessionUser.email,
         organizationId: orgId,
         provider: providerInput,
         model,


### PR DESCRIPTION
This fixes sandbox startup when the base image lacks a `user` account by creating it in the Docker image. It also configures git `user.name` and `user.email` automatically in sandbox startup using the authenticated user context. Both REST and oRPC task execution paths now pass user identity through to task execution. Verified with format, lint, and build.