### PR TITLE
fix: resolve HTTPS origin behind Vite proxy for OAuth

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,9 @@ export default defineConfig({
       "/api": {
         target: "http://localhost:8787",
         changeOrigin: true,
+        headers: {
+          "X-Forwarded-Proto": "https",
+        },
       },
     },
   },

--- a/worker/src/auth.ts
+++ b/worker/src/auth.ts
@@ -12,16 +12,28 @@ const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
 function resolveOrigin(request: Request): string {
   const requestOrigin = new URL(request.url).origin;
   const originHeader = request.headers.get("origin");
-  if (!originHeader) {
-    return requestOrigin;
+
+  let origin: string;
+  if (originHeader) {
+    try {
+      origin = isLocalOrigin(new URL(originHeader).origin)
+        ? new URL(originHeader).origin
+        : requestOrigin;
+    } catch {
+      origin = requestOrigin;
+    }
+  } else {
+    origin = requestOrigin;
   }
 
-  try {
-    const origin = new URL(originHeader).origin;
-    return isLocalOrigin(origin) ? origin : requestOrigin;
-  } catch {
-    return requestOrigin;
+  const proto = request.headers.get("x-forwarded-proto");
+  if (proto) {
+    const url = new URL(origin);
+    url.protocol = `${proto}:`;
+    return url.origin;
   }
+
+  return origin;
 }
 
 function isLocalOrigin(origin: string): boolean {


### PR DESCRIPTION
## Summary

Fixed OAuth state_mismatch errors occurring during GitHub authentication when the frontend runs over HTTPS but requests are proxied through Vite to the Worker without explicit protocol information.

## Changes

- **vite.config.ts**: Added `X-Forwarded-Proto: https` header to the `/api` proxy to signal the original request protocol to the Worker.
- **worker/src/auth.ts**: Updated `resolveOrigin` to read and apply the `X-Forwarded-Proto` header when constructing the auth baseURL, ensuring it correctly uses HTTPS for local development.

This ensures the auth library sets secure cookies and validates OAuth state correctly even when behind a dev proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)