### PR TITLE
Improve task stream activity details

### DIFF
--- a/frontend/src/components/task-stream-activity.tsx
+++ b/frontend/src/components/task-stream-activity.tsx
@@ -26,6 +26,7 @@ export interface TaskStreamActivityItem {
   id: string;
   icon: TaskStreamActivityIcon;
   label: string;
+  details?: string[];
   tone?: "default" | "muted" | "error" | "success";
   spinning?: boolean;
 }
@@ -50,24 +51,43 @@ export function TaskStreamActivity({ items }: { items: TaskStreamActivityItem[] 
                   item.tone === "error" ? "text-destructive" : "text-muted-foreground",
                 )}
               />
-              <span
-                className={cn(
-                  "whitespace-pre-wrap",
-                  item.tone === "error" ? "text-destructive" : "text-foreground",
-                )}
-              >
-                {action}
-              </span>
-              {details ? (
-                <span
-                  className={cn(
-                    "whitespace-pre-wrap text-muted-foreground",
-                    item.tone === "error" && "text-destructive/80",
-                  )}
-                >
-                  {details}
-                </span>
-              ) : null}
+              <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 items-start gap-1">
+                  <span
+                    className={cn(
+                      "whitespace-pre-wrap",
+                      item.tone === "error" ? "text-destructive" : "text-foreground",
+                    )}
+                  >
+                    {action}
+                  </span>
+                  {details ? (
+                    <span
+                      className={cn(
+                        "whitespace-pre-wrap text-muted-foreground",
+                        item.tone === "error" && "text-destructive/80",
+                      )}
+                    >
+                      {details}
+                    </span>
+                  ) : null}
+                </div>
+                {item.details && item.details.length > 0 ? (
+                  <div className="mt-1 space-y-0.5 text-[11px] text-muted-foreground">
+                    {item.details.map((detail) => (
+                      <div
+                        key={`${item.id}-${detail}`}
+                        className={cn(
+                          "whitespace-pre-wrap break-words",
+                          item.tone === "error" && "text-destructive/80",
+                        )}
+                      >
+                        {detail}
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
             </div>
           );
         })}

--- a/frontend/src/pages/task-page.tsx
+++ b/frontend/src/pages/task-page.tsx
@@ -579,6 +579,7 @@ function buildChronologicalTimeline(args: {
           id: activity.id,
           icon: activity.icon,
           label: activity.label,
+          details: activity.details,
           tone: activity.tone,
           spinning: activity.spinning,
         },
@@ -671,11 +672,15 @@ function openCodeEventToActivityItem(
 
   if (parsed.type === "command.executed") {
     const { name, arguments: args } = parsed.properties;
+    const details: string[] = [];
+    appendDetail(details, "Arguments", args, 300);
+
     return {
       id: event.id,
       stateKey: `command:${event.id}`,
       icon: "terminal",
-      label: args ? `${name}: ${args}` : name,
+      label: `Command: ${name}`,
+      details: details.length > 0 ? details : undefined,
       tone: "muted",
       createdAt: event.createdAt,
     };
@@ -683,11 +688,19 @@ function openCodeEventToActivityItem(
 
   if (parsed.type === "session.status") {
     const { sessionID, status } = parsed.properties;
+    const details: string[] = [];
+
+    if (status.type === "retry") {
+      appendDetail(details, "Attempt", status.attempt);
+      appendDetail(details, "Reason", status.message);
+    }
+
     return {
       id: event.id,
       stateKey: `session:${sessionID}`,
       icon: status.type === "idle" ? "success" : "status",
       label: status.type === "idle" ? "Session idle" : `Session ${status.type}`,
+      details: details.length > 0 ? details : undefined,
       tone: "muted",
       spinning: status.type === "busy",
       createdAt: event.createdAt,
@@ -696,13 +709,16 @@ function openCodeEventToActivityItem(
 
   if (parsed.type === "session.error") {
     const { sessionID, error } = parsed.properties;
-    const rawMessage = error?.data && "message" in error.data ? error.data.message : undefined;
-    const message = typeof rawMessage === "string" ? rawMessage : "Session error";
+    const message = getErrorMessage(error) ?? "Session error";
+    const details: string[] = [];
+    appendDetail(details, "Error type", getErrorName(error));
+
     return {
       id: event.id,
       stateKey: `session:${sessionID ?? "default"}`,
       icon: "error",
       label: message,
+      details: details.length > 0 ? details : undefined,
       tone: "error",
       createdAt: event.createdAt,
     };
@@ -710,11 +726,16 @@ function openCodeEventToActivityItem(
 
   if (parsed.type === "permission.updated") {
     const permission = parsed.properties;
+    const details: string[] = [];
+    appendDetail(details, "Type", permission.type);
+    appendDetail(details, "Pattern", formatPermissionPattern(permission.pattern));
+
     return {
       id: event.id,
       stateKey: `permission:${permission.id ?? permission.title ?? "default"}`,
       icon: "permission",
       label: permission.title ?? "Permission requested",
+      details: details.length > 0 ? details : undefined,
       tone: "muted",
       createdAt: event.createdAt,
     };
@@ -722,6 +743,7 @@ function openCodeEventToActivityItem(
 
   if (parsed.type === "permission.replied") {
     const { permissionID, response } = parsed.properties;
+
     return {
       id: event.id,
       stateKey: `permission:${permissionID ?? "default"}`,
@@ -734,11 +756,19 @@ function openCodeEventToActivityItem(
 
   if (parsed.type === "todo.updated") {
     const { todos } = parsed.properties;
+    const details: string[] = [];
+    appendDetail(details, "Status", summarizeTodoStatusCounts(todos));
+    const focusTodo =
+      todos.find((todo) => todo.status === "in_progress") ??
+      todos.find((todo) => todo.status === "pending");
+    appendDetail(details, "Focus", focusTodo?.content);
+
     return {
       id: event.id,
       stateKey: "todo-list",
       icon: "tool",
       label: `Todo list updated (${todos.length})`,
+      details: details.length > 0 ? details : undefined,
       tone: "muted",
       createdAt: event.createdAt,
     };
@@ -755,6 +785,7 @@ function messagePartToActivityItem(
 
   if (part.type === "reasoning") {
     const isComplete = typeof part.time.end === "number";
+
     return {
       id: event.id,
       stateKey: `reasoning:${part.id ?? part.messageID}`,
@@ -766,13 +797,27 @@ function messagePartToActivityItem(
     };
   }
 
-  if (part.type === "step-start" || part.type === "step-finish") {
+  if (part.type === "step-start") {
     const stepKey = part.snapshot ?? part.messageID;
+
     return {
       id: event.id,
       stateKey: `step:${stepKey}`,
       icon: "thinking",
-      label: part.type === "step-finish" ? "Step complete" : "Working on next step",
+      label: "Step: started",
+      tone: "muted",
+      createdAt: event.createdAt,
+    };
+  }
+
+  if (part.type === "step-finish") {
+    const stepKey = part.snapshot ?? part.messageID;
+
+    return {
+      id: event.id,
+      stateKey: `step:${stepKey}`,
+      icon: "thinking",
+      label: "Step: complete",
       tone: "muted",
       createdAt: event.createdAt,
     };
@@ -781,14 +826,38 @@ function messagePartToActivityItem(
   if (part.type === "tool") {
     const toolName = part.tool;
     const status = part.state.status;
-    const title = "title" in part.state ? part.state.title : undefined;
+    const details: string[] = [];
     const callId = part.callID ?? part.id;
+    appendDetail(details, "Input", part.state.input, 300);
+
+    if (status === "pending") {
+      appendDetail(details, "Request", part.state.raw, 300);
+    }
+
+    if (status === "running") {
+      appendDetail(details, "Action", part.state.title);
+    }
+
+    if (status === "completed") {
+      appendDetail(details, "Result", part.state.title);
+      appendDetail(details, "Output", part.state.output, 320);
+
+      const attachmentCount = part.state.attachments?.length ?? 0;
+      if (attachmentCount > 0) {
+        details.push(`Attachments: ${attachmentCount}`);
+      }
+    }
+
+    if (status === "error") {
+      appendDetail(details, "Error", part.state.error, 320);
+    }
 
     return {
       id: event.id,
       stateKey: `tool:${callId}`,
       icon: getToolActivityIcon(toolName),
-      label: title ? `${toolName}: ${status} (${title})` : `${toolName}: ${status}`,
+      label: `${toolName}: ${status}`,
+      details: details.length > 0 ? details : undefined,
       tone: status === "error" ? "error" : status === "completed" ? "success" : "muted",
       spinning: status === "running",
       createdAt: event.createdAt,
@@ -796,6 +865,196 @@ function messagePartToActivityItem(
   }
 
   return null;
+}
+
+function appendDetail(details: string[], key: string, value: unknown, maxLength = 220): void {
+  const formatted = formatDetailValue(value, maxLength);
+  if (!formatted) {
+    return;
+  }
+
+  details.push(`${key}: ${formatted}`);
+}
+
+function formatDetailValue(value: unknown, maxLength = 220): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    const normalized = value.trim().replace(/\s+/g, " ");
+    if (normalized.length === 0) {
+      return null;
+    }
+    return truncateText(normalized, maxLength);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return null;
+    }
+
+    const values = value
+      .map((item) => formatDetailValue(item, Math.floor(maxLength / 2)) ?? "")
+      .filter((item) => item.length > 0);
+
+    if (values.length === 0) {
+      return null;
+    }
+
+    const rendered = values.slice(0, 5).join(", ");
+    const suffix = values.length > 5 ? ", ..." : "";
+    return truncateText(`${rendered}${suffix}`, maxLength);
+  }
+
+  if (typeof value === "object") {
+    const formattedObject = formatObjectDetailValue(value as Record<string, unknown>, maxLength);
+    if (!formattedObject) {
+      return null;
+    }
+
+    return formattedObject;
+  }
+
+  return null;
+}
+
+function formatObjectDetailValue(value: Record<string, unknown>, maxLength: number): string | null {
+  const entries = Object.entries(value).filter(([key, entryValue]) => {
+    if (entryValue === null || entryValue === undefined) {
+      return false;
+    }
+
+    return !isHiddenDetailKey(key);
+  });
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const preview = entries
+    .slice(0, 5)
+    .map(([key, entryValue]) => {
+      const formattedValue = formatDetailValue(entryValue, 90);
+      if (!formattedValue) {
+        return null;
+      }
+
+      return `${toDisplayKey(key)}: ${formattedValue}`;
+    })
+    .filter((entry): entry is string => entry !== null);
+
+  if (preview.length === 0) {
+    return null;
+  }
+
+  const suffix = entries.length > 5 ? ", ..." : "";
+  return truncateText(`${preview.join(", ")}${suffix}`, maxLength);
+}
+
+function isHiddenDetailKey(key: string): boolean {
+  const normalized = key.trim().toLowerCase();
+  return (
+    normalized === "id" ||
+    normalized === "sessionid" ||
+    normalized === "messageid" ||
+    normalized === "callid"
+  );
+}
+
+function toDisplayKey(key: string): string {
+  const separated = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replaceAll("_", " ")
+    .trim();
+  const normalized = separated.toLowerCase();
+  if (normalized.length === 0) {
+    return "";
+  }
+
+  return `${normalized[0]?.toUpperCase() ?? ""}${normalized.slice(1)}`;
+}
+
+function truncateText(value: string, maxLength = 220): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  if (maxLength <= 3) {
+    return value.slice(0, maxLength);
+  }
+
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+function getErrorMessage(error: unknown): string | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  const candidateData = (error as Record<string, unknown>).data;
+  if (!candidateData || typeof candidateData !== "object") {
+    return null;
+  }
+
+  const candidateMessage = (candidateData as Record<string, unknown>).message;
+  return typeof candidateMessage === "string" ? candidateMessage : null;
+}
+
+function getErrorName(error: unknown): string | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+
+  const candidateName = (error as Record<string, unknown>).name;
+  return typeof candidateName === "string" ? candidateName : null;
+}
+
+function formatPermissionPattern(pattern: string | string[] | undefined): string | null {
+  if (!pattern) {
+    return null;
+  }
+
+  if (typeof pattern === "string") {
+    return truncateText(pattern, 220);
+  }
+
+  if (pattern.length === 0) {
+    return null;
+  }
+
+  return truncateText(pattern.join(", "), 220);
+}
+
+function summarizeTodoStatusCounts(todos: Array<{ status: string }>): string {
+  const counts = new Map<string, number>();
+  for (const todo of todos) {
+    counts.set(todo.status, (counts.get(todo.status) ?? 0) + 1);
+  }
+
+  const orderedStatuses = ["in_progress", "pending", "completed", "cancelled"];
+  const summary: string[] = [];
+
+  for (const status of orderedStatuses) {
+    const count = counts.get(status) ?? 0;
+    if (count > 0) {
+      summary.push(`${status} ${count}`);
+      counts.delete(status);
+    }
+  }
+
+  const remainingEntries = Array.from(counts.entries()).toSorted((a, b) =>
+    a[0].localeCompare(b[0]),
+  );
+  for (const [status, count] of remainingEntries) {
+    summary.push(`${status} ${count}`);
+  }
+
+  return summary.join(", ");
 }
 
 function getToolActivityIcon(toolName: string): TaskStreamActivityIcon {


### PR DESCRIPTION
This PR improves task stream activity rendering on the task page with optional secondary detail lines for relevant events and tool calls. It replaces raw and ID-heavy metadata with friendlier summaries, while keeping thought and step entries minimal and omitting duration/context/session/message/call ID details. It also updates timeline mapping so the new detail payload is preserved and displayed.