### PR TITLE
fix(frontend): avoid crash on deleted active task

### DIFF
--- a/frontend/src/components/layout/task-list.tsx
+++ b/frontend/src/components/layout/task-list.tsx
@@ -72,18 +72,12 @@ export function TaskList() {
     }
 
     const deletingTaskId = taskToDelete.id;
-    const isDeletingActiveTask = pathname === `/tasks/${deletingTaskId}`;
 
     setDeletingTask(true);
     setDeleteError(null);
 
     try {
-      const tx = tasksCollection.delete(deletingTaskId);
-      await tx.isPersisted.promise;
-
-      if (isDeletingActiveTask) {
-        navigate({ to: "/", replace: true });
-      }
+      tasksCollection.delete(deletingTaskId);
       setTaskToDelete(null);
     } catch (error) {
       setDeleteError(error instanceof Error ? error.message : "Failed to delete task");

--- a/frontend/src/routes/_layout.tasks.$taskId.tsx
+++ b/frontend/src/routes/_layout.tasks.$taskId.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { Navigate, createFileRoute } from "@tanstack/react-router";
 import { TaskPage } from "@/pages/task-page";
 import { eq, useLiveQuery } from "@tanstack/react-db";
 import { projectsCollection, taskMessagesCollection, tasksCollection } from "@/lib/collections";
@@ -12,9 +12,7 @@ export const Route = createFileRoute("/_layout/tasks/$taskId")({
     ]),
   component: () => {
     const { taskId } = Route.useParams();
-    const {
-      data: [result],
-    } = useLiveQuery(
+    const { data, isLoading } = useLiveQuery(
       (q) =>
         q
           .from({ task: tasksCollection })
@@ -25,14 +23,23 @@ export const Route = createFileRoute("/_layout/tasks/$taskId")({
       [taskId],
     );
 
+    const openedTask = data[0];
+    if (isLoading) {
+      return null;
+    }
+
+    if (!openedTask) {
+      return <Navigate to="/" replace />;
+    }
+
     return (
       <TaskPage
         key={taskId}
         taskId={taskId}
-        title={result.task.title}
-        projectName={result.project?.name ?? "No project"}
-        error={result.task.error ?? null}
-        isRunning={result.task.status === "running"}
+        title={openedTask.task.title}
+        projectName={openedTask.project?.name ?? "No project"}
+        error={openedTask.task.error ?? null}
+        isRunning={openedTask.task.status === "running"}
       />
     );
   },


### PR DESCRIPTION
This fixes the runtime error when the currently open task gets deleted. The task route now handles missing task records safely by checking loading state and redirecting when the task is gone. The task page props are now sourced from a guarded openedTask value instead of dereferencing an assumed query result. The sidebar delete action no longer performs explicit route navigation and directly issues the delete mutation.