### PR TITLE
Handle stream listener updates when stream ID changes

### DIFF
--- a/frontend/src/components/layout/task-list.tsx
+++ b/frontend/src/components/layout/task-list.tsx
@@ -42,6 +42,7 @@ export function TaskList() {
         project_id: defaultProject.id,
         title: "New task",
         status: "open",
+        stream_id: null,
         branch: null,
         error: null,
         created_at: BigInt(now),

--- a/frontend/src/lib/collections.ts
+++ b/frontend/src/lib/collections.ts
@@ -23,6 +23,7 @@ const taskSchema = z.object({
   project_id: z.string().nullable(),
   title: z.string(),
   status: z.string(),
+  stream_id: z.string().nullable(),
   branch: z.string().nullable(),
   error: z.string().nullable(),
   created_at: z.bigint(),

--- a/frontend/src/lib/use-task-event-stream.ts
+++ b/frontend/src/lib/use-task-event-stream.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { stream } from "@durable-streams/client";
+import type { TaskStreamEvent } from "../../../shared/task-stream-events";
+import { getTaskEventStreamUrl } from "./api";
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
+function appendUniqueEvents(
+  previousEvents: TaskStreamEvent[],
+  nextEvents: readonly TaskStreamEvent[],
+): TaskStreamEvent[] {
+  if (nextEvents.length === 0) {
+    return previousEvents;
+  }
+
+  const seenEventIds = new Set(previousEvents.map((event) => event.id));
+  const mergedEvents = [...previousEvents];
+  let didAddEvent = false;
+
+  for (const event of nextEvents) {
+    if (seenEventIds.has(event.id)) {
+      continue;
+    }
+
+    seenEventIds.add(event.id);
+    mergedEvents.push(event);
+    didAddEvent = true;
+  }
+
+  return didAddEvent ? mergedEvents : previousEvents;
+}
+
+interface UseTaskEventStreamArgs {
+  taskId: string;
+  streamId: string | null;
+}
+
+export function useTaskEventStream(args: UseTaskEventStreamArgs): TaskStreamEvent[] {
+  const { taskId, streamId } = args;
+  const [runEvents, setRunEvents] = useState<TaskStreamEvent[]>([]);
+
+  useEffect(() => {
+    setRunEvents([]);
+  }, [taskId, streamId]);
+
+  useEffect(() => {
+    if (!streamId) {
+      return;
+    }
+
+    const abortController = new AbortController();
+    const streamUrl = getTaskEventStreamUrl(taskId);
+
+    stream<TaskStreamEvent>({
+      url: streamUrl,
+      offset: "-1",
+      live: "sse",
+      json: true,
+      signal: abortController.signal,
+    })
+      .then((res) => {
+        if (abortController.signal.aborted) {
+          return;
+        }
+
+        res.subscribeJson(({ items }) => {
+          setRunEvents((previousEvents) => appendUniqueEvents(previousEvents, items));
+        });
+      })
+      .catch((error: unknown) => {
+        if (isAbortError(error)) {
+          return;
+        }
+
+        console.error("Failed to subscribe to task stream", error);
+      });
+
+    return () => {
+      abortController.abort();
+    };
+  }, [taskId, streamId]);
+
+  return runEvents;
+}

--- a/frontend/src/pages/task-page.tsx
+++ b/frontend/src/pages/task-page.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { useLiveQuery, eq } from "@tanstack/react-db";
-import { stream } from "@durable-streams/client";
 import {
   AlertCircle,
   Check,
@@ -27,8 +26,8 @@ import {
   parseOpenCodeEventPayload,
   type TaskStreamEvent,
 } from "../../../shared/task-stream-events";
-import { getTaskEventStreamUrl } from "../lib/api";
 import { taskMessagesCollection, tasksCollection } from "../lib/collections";
+import { useTaskEventStream } from "../lib/use-task-event-stream";
 
 function CollapsedActivityGroup({ items }: { items: TaskStreamActivityItem[] }) {
   const [expanded, setExpanded] = useState(false);
@@ -62,6 +61,7 @@ function CollapsedActivityGroup({ items }: { items: TaskStreamActivityItem[] }) 
 interface TaskPageProps {
   taskId: string;
   projectName: string;
+  streamId: string | null;
   branch: string | null;
   pullRequest: {
     prNumber: number;
@@ -90,6 +90,7 @@ export function TaskPage({
   taskId,
   title,
   projectName,
+  streamId,
   branch,
   pullRequest,
   error,
@@ -97,7 +98,7 @@ export function TaskPage({
 }: TaskPageProps) {
   const [input, setInput] = useSessionState(sessionStateKeys.taskInput(taskId), "");
   const [sending, setSending] = useState(false);
-  const [runEvents, setRunEvents] = useState<TaskStreamEvent[]>([]);
+  const runEvents = useTaskEventStream({ taskId, streamId });
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleInput, setTitleInput] = useState("");
   const [savingTitle, setSavingTitle] = useState(false);
@@ -136,40 +137,6 @@ export function TaskPage({
 
   useEffect(() => {
     inputRef.current?.focus();
-  }, [taskId]);
-
-  useEffect(() => {
-    const abortController = new AbortController();
-    const seenEventIds = new Set<string>();
-
-    const applyEvent = (event: TaskStreamEvent) => {
-      if (seenEventIds.has(event.id)) {
-        return;
-      }
-      seenEventIds.add(event.id);
-
-      setRunEvents((prev) => [...prev, event]);
-    };
-
-    const streamUrl = getTaskEventStreamUrl(taskId);
-
-    stream<TaskStreamEvent>({
-      url: streamUrl,
-      offset: "-1",
-      live: "sse",
-      json: true,
-      signal: abortController.signal,
-    }).then((res) => {
-      res.subscribeJson(({ items }) => {
-        for (const event of items) {
-          applyEvent(event);
-        }
-      });
-    });
-
-    return () => {
-      abortController.abort();
-    };
   }, [taskId]);
 
   useEffect(() => {

--- a/frontend/src/routes/_layout.tasks.$taskId.tsx
+++ b/frontend/src/routes/_layout.tasks.$taskId.tsx
@@ -84,6 +84,7 @@ export const Route = createFileRoute("/_layout/tasks/$taskId")({
         taskId={taskId}
         title={openedTask.task.title}
         projectName={openedTask.project?.name ?? "No project"}
+        streamId={openedTask.task.stream_id ?? null}
         branch={openedTask.task.branch ?? null}
         pullRequest={
           pullRequest


### PR DESCRIPTION
This refactors task event subscription into a new  hook so stream listening can react to  updates, including  transitions. The hook resets transient run events when  or  changes, re-subscribes with cleanup via , and deduplicates incoming events by id. The task route now passes  into , and the frontend task schema/optimistic task creation include nullable  so data shape stays consistent before server sync. Validation run for this branch: , Found 0 warnings and 0 errors.
Finished in 145ms on 86 files with 127 rules using 10 threads., and .