### PR TITLE
fix(mobile): full-width sidebar and swipe-to-open on task page

### DIFF
--- a/frontend/src/components/layout.tsx
+++ b/frontend/src/components/layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 import { cn } from "../lib/utils";
@@ -6,11 +6,16 @@ import { useSession } from "../lib/auth-client";
 import { MobileHeader } from "./layout/mobile-header";
 import { Sidebar } from "./layout/sidebar";
 
+const EDGE_THRESHOLD = 30; // px from left edge to start swipe
+const SWIPE_MIN_DISTANCE = 50; // minimum horizontal swipe distance to trigger
+
 export function Layout() {
   const { data: session, isPending } = useSession();
   const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const sidebarOpenRef = useRef(sidebarOpen);
+  sidebarOpenRef.current = sidebarOpen;
 
   useEffect(() => {
     if (!isPending && !session) {
@@ -22,6 +27,47 @@ export function Layout() {
   useEffect(() => {
     setSidebarOpen(false);
   }, [pathname]);
+
+  // Intercept left-edge swipe on mobile to open sidebar instead of browser back
+  useEffect(() => {
+    let startX = 0;
+    let startY = 0;
+    let isEdgeSwipe = false;
+
+    const onTouchStart = (e: TouchEvent) => {
+      const touch = e.touches[0];
+      startX = touch.clientX;
+      startY = touch.clientY;
+      isEdgeSwipe = startX < EDGE_THRESHOLD && !sidebarOpenRef.current;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (!isEdgeSwipe) return;
+      // Prevent the browser's back-swipe gesture from firing
+      e.preventDefault();
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      if (!isEdgeSwipe) return;
+      const touch = e.changedTouches[0];
+      const deltaX = touch.clientX - startX;
+      const deltaY = Math.abs(touch.clientY - startY);
+      if (deltaX > SWIPE_MIN_DISTANCE && deltaX > deltaY) {
+        setSidebarOpen(true);
+      }
+      isEdgeSwipe = false;
+    };
+
+    document.addEventListener("touchstart", onTouchStart, { passive: true });
+    document.addEventListener("touchmove", onTouchMove, { passive: false });
+    document.addEventListener("touchend", onTouchEnd, { passive: true });
+
+    return () => {
+      document.removeEventListener("touchstart", onTouchStart);
+      document.removeEventListener("touchmove", onTouchMove);
+      document.removeEventListener("touchend", onTouchEnd);
+    };
+  }, []);
 
   if (isPending) {
     return (
@@ -47,8 +93,8 @@ export function Layout() {
       {/* Sidebar */}
       <div
         className={cn(
-          "fixed inset-y-0 left-0 z-50 w-64 border-r border-border bg-card transition-transform duration-200 ease-in-out",
-          "md:relative md:translate-x-0",
+          "fixed inset-y-0 left-0 z-50 w-full border-r border-border bg-card transition-transform duration-200 ease-in-out",
+          "md:relative md:w-64 md:translate-x-0",
           sidebarOpen ? "translate-x-0" : "-translate-x-full",
         )}
       >


### PR DESCRIPTION
- Make the sidebar full width on mobile (w-full, md:w-64)
- Add non-passive touchmove listener on the left edge (30px threshold)
  to preventDefault on iOS Safari back-swipe gesture
- On a sufficient rightward edge swipe (50px), open the sidebar instead

https://claude.ai/code/session_0159jsqvn2tkZ2RMArEs2iLW