### PR TITLE
fix(frontend): hide review/checks status badges when unknown

### DIFF
--- a/frontend/src/pages/task-page.tsx
+++ b/frontend/src/pages/task-page.tsx
@@ -411,23 +411,27 @@ export function TaskPage({
                 </a>
               </Button>
               <div className="flex flex-wrap justify-end gap-1">
-                <span
-                  className={cn(
-                    "rounded border px-2 py-0.5 text-[11px] font-medium",
-                    getReviewStatusClasses(pullRequest.reviewState),
-                  )}
-                >
-                  Review: {humanizePullRequestStatus(pullRequest.reviewState)}
-                </span>
-                <span
-                  className={cn(
-                    "rounded border px-2 py-0.5 text-[11px] font-medium",
-                    getChecksStatusClasses(pullRequest.checksState, pullRequest.checksConclusion),
-                  )}
-                >
-                  Checks:{" "}
-                  {formatChecksStatus(pullRequest.checksState, pullRequest.checksConclusion)}
-                </span>
+                {pullRequest.reviewState != null ? (
+                  <span
+                    className={cn(
+                      "rounded border px-2 py-0.5 text-[11px] font-medium",
+                      getReviewStatusClasses(pullRequest.reviewState),
+                    )}
+                  >
+                    Review: {humanizePullRequestStatus(pullRequest.reviewState)}
+                  </span>
+                ) : null}
+                {pullRequest.checksState != null || pullRequest.checksConclusion != null ? (
+                  <span
+                    className={cn(
+                      "rounded border px-2 py-0.5 text-[11px] font-medium",
+                      getChecksStatusClasses(pullRequest.checksState, pullRequest.checksConclusion),
+                    )}
+                  >
+                    Checks:{" "}
+                    {formatChecksStatus(pullRequest.checksState, pullRequest.checksConclusion)}
+                  </span>
+                ) : null}
               </div>
             </div>
           ) : null}


### PR DESCRIPTION
Do not render Review or Checks status indicators when their state is
null (unknown). Previously, both badges were always shown, displaying
"unknown" when no status had been received yet.

https://claude.ai/code/session_012z3CLrvnv9tmSGN5nnEuGT