### PR TITLE
fix(auth): use www.clanki.ai as production URL

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -6,7 +6,7 @@ import { eq, and } from "drizzle-orm";
 import * as schema from "./db/schema";
 import { getDb } from "./db/client";
 
-const PRODUCTION_URL = "https://clanki.ai";
+const PRODUCTION_URL = "https://www.clanki.ai";
 const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
 
 function resolveOrigin(request: Request): string {


### PR DESCRIPTION
## Summary

The production domain `clanki.ai` has a 307 redirect to `www.clanki.ai`, but the auth configuration used `clanki.ai` without www. This caused the oAuthProxy plugin to treat production requests as preview deployments, creating an infinite redirect loop that timed out after 300 seconds on Vercel.

## Changes

- Updated `PRODUCTION_URL` from `https://clanki.ai` to `https://www.clanki.ai` to match the actual domain after redirect

## Next Steps

Update the GitHub OAuth app's authorized callback URL to `https://www.clanki.ai/api/auth/callback/github` in your GitHub OAuth app settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)