### PR TITLE
fix: remove explicit Vercel sandbox credential envs

### DIFF
--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -20,9 +20,6 @@ export type AppEnv = {
 
   TASK_RUNNER_CALLBACK_SECRET?: string;
 
-  VERCEL_TOKEN?: string;
-  VERCEL_PROJECT_ID?: string;
-  VERCEL_TEAM_ID?: string;
   VERCEL_OIDC_TOKEN?: string;
   VERCEL_SANDBOX_TIMEOUT_MS?: string;
 };
@@ -59,9 +56,6 @@ export function getEnv(): AppEnv {
 
     TASK_RUNNER_CALLBACK_SECRET: process.env.TASK_RUNNER_CALLBACK_SECRET,
 
-    VERCEL_TOKEN: process.env.VERCEL_TOKEN,
-    VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID,
-    VERCEL_TEAM_ID: process.env.VERCEL_TEAM_ID,
     VERCEL_OIDC_TOKEN: process.env.VERCEL_OIDC_TOKEN,
     VERCEL_SANDBOX_TIMEOUT_MS: process.env.VERCEL_SANDBOX_TIMEOUT_MS,
   };

--- a/src/server/lib/sandbox.ts
+++ b/src/server/lib/sandbox.ts
@@ -32,9 +32,6 @@ export type TaskSandbox = {
 };
 
 export type SandboxEnv = {
-  VERCEL_TOKEN?: string;
-  VERCEL_PROJECT_ID?: string;
-  VERCEL_TEAM_ID?: string;
   VERCEL_SANDBOX_TIMEOUT_MS?: string;
 };
 
@@ -202,15 +199,12 @@ export async function getTaskSandbox(
   env: SandboxEnv,
   sandboxId?: string | null,
 ): Promise<TaskSandbox> {
-  const credentials = resolveCredentials(env);
-
   let sandbox: VercelSandbox | null = null;
   const normalizedSandboxId = sandboxId?.trim() ?? "";
 
   if (normalizedSandboxId.length > 0) {
     try {
       const existing = await VercelSandbox.get({
-        ...credentials,
         sandboxId: normalizedSandboxId,
       });
       if (existing.status === "running" || existing.status === "pending") {
@@ -223,7 +217,6 @@ export async function getTaskSandbox(
 
   if (!sandbox) {
     sandbox = await VercelSandbox.create({
-      ...credentials,
       ports: [OPENCODE_PORT],
       runtime: "node24",
       timeout: resolveSandboxTimeout(env),
@@ -253,33 +246,6 @@ export async function getOpenCodeClient(sandbox: TaskSandbox, directory: string,
       directory,
     }) as OpencodeClient,
   };
-}
-
-function resolveCredentials(env: SandboxEnv): {
-  token?: string;
-  projectId?: string;
-  teamId?: string;
-} {
-  const token = env.VERCEL_TOKEN?.trim();
-  const projectId = env.VERCEL_PROJECT_ID?.trim();
-  const teamId = env.VERCEL_TEAM_ID?.trim();
-
-  const hasAnyExplicit = Boolean(token || projectId || teamId);
-  const hasAllExplicit = Boolean(token && projectId && teamId);
-
-  if (hasAnyExplicit && !hasAllExplicit) {
-    throw new Error("Set VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID together.");
-  }
-
-  if (hasAllExplicit) {
-    return {
-      token,
-      projectId,
-      teamId,
-    };
-  }
-
-  return {};
 }
 
 function resolveSandboxTimeout(env: SandboxEnv): number {


### PR DESCRIPTION
Removes VERCEL_TOKEN, VERCEL_PROJECT_ID, and VERCEL_TEAM_ID from server env typing and env loading. Removes explicit credential handling in sandbox startup, including credential spreading into VercelSandbox.get/create and the custom guard function. This makes sandbox auth rely on the SDK's default credential resolution (OIDC/device flow/token discovery). Pre-commit checks were run: format, lint:fix, knip, and build.