### PR TITLE
fix: disable caching for electric SSE responses

### DIFF
--- a/src/server/lib/electric.ts
+++ b/src/server/lib/electric.ts
@@ -33,6 +33,7 @@ export const electricFn = async ({ request, table, where }: ElectricOptions) => 
   const headers = new Headers(response.headers);
   headers.delete(`content-encoding`);
   headers.delete(`content-length`);
+  headers.set(`cache-control`, `no-store`);
 
   return new Response(response.body, {
     status: response.status,


### PR DESCRIPTION
This change adds a `cache-control: no-store` header to responses returned by `electricFn` in `src/server/lib/electric.ts`. It prevents intermediary/browser caching of streamed SSE payloads while preserving existing forwarded headers and status handling.