### PR TITLE
Fix auth session failures from DB connection exhaustion

### DIFF
--- a/src/server/db/client.ts
+++ b/src/server/db/client.ts
@@ -8,19 +8,42 @@ type DbEnv = {
   DATABASE_URL?: string;
 };
 
+type DbClientCacheEntry = {
+  url: string;
+  db: AppDb;
+};
+
+type GlobalWithDbCache = typeof globalThis & {
+  __clankiDbClientCache?: DbClientCacheEntry;
+};
+
+const globalWithDbCache = globalThis as GlobalWithDbCache;
+
+function createDb(url: string): AppDb {
+  const sql = postgres(url, {
+    fetch_types: false,
+    prepare: false,
+    // Keep per-runtime connection usage predictable in serverless deployments.
+    max: 1,
+    idle_timeout: 20,
+    connect_timeout: 10,
+  });
+
+  return drizzle({ client: sql, schema });
+}
+
 export function getDb(env: DbEnv): AppDb {
   const url = env.DATABASE_URL;
   if (!url) {
     throw new Error("Database connection string is missing");
   }
 
-  const sql = postgres(url, {
-    fetch_types: false,
-    prepare: false,
-    max: 5,
-    idle_timeout: 20,
-    connect_timeout: 10,
-  });
+  const cached = globalWithDbCache.__clankiDbClientCache;
+  if (cached && cached.url === url) {
+    return cached.db;
+  }
 
-  return drizzle({ client: sql, schema });
+  const db = createDb(url);
+  globalWithDbCache.__clankiDbClientCache = { url, db };
+  return db;
 }

--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -3,6 +3,7 @@ import { getRequest } from "@tanstack/react-start/server";
 import { createAuth } from "./auth";
 import { getDb } from "./db/client";
 import { getEnv } from "./env";
+import { toSessionErrorResponse } from "./session-error-response";
 
 export type SessionContext = {
   session: { userId: string; activeOrganizationId?: string | null };
@@ -13,10 +14,15 @@ export const authMiddleware = createMiddleware().server(async ({ next }) => {
   const request = getRequest();
   const env = getEnv();
   const auth = createAuth(env, request);
-  const result = await auth.api.getSession({ headers: request.headers });
+  let result: Awaited<ReturnType<typeof auth.api.getSession>>;
+  try {
+    result = await auth.api.getSession({ headers: request.headers });
+  } catch (error) {
+    throw toSessionErrorResponse(error);
+  }
 
   if (!result) {
-    throw new Error("Unauthorized");
+    throw new Response("Unauthorized", { status: 401 });
   }
 
   const session: SessionContext = {

--- a/src/server/requireSession.ts
+++ b/src/server/requireSession.ts
@@ -1,6 +1,7 @@
 import { createAuth } from "./auth";
 import { getEnv } from "./env";
 import { SessionContext } from "./middleware";
+import { toSessionErrorResponse } from "./session-error-response";
 
 /**
  * Standalone session helper for API routes (not server functions).
@@ -9,7 +10,12 @@ import { SessionContext } from "./middleware";
 export async function requireSession(request: Request): Promise<SessionContext> {
   const env = getEnv();
   const auth = createAuth(env, request);
-  const result = await auth.api.getSession({ headers: request.headers });
+  let result: Awaited<ReturnType<typeof auth.api.getSession>>;
+  try {
+    result = await auth.api.getSession({ headers: request.headers });
+  } catch (error) {
+    throw toSessionErrorResponse(error);
+  }
 
   if (!result) {
     throw new Response("Unauthorized", { status: 401 });

--- a/src/server/session-error-response.ts
+++ b/src/server/session-error-response.ts
@@ -1,0 +1,60 @@
+const CONNECTION_SLOT_ERROR_CODE = "53300";
+const CONNECTION_SLOT_ERROR_TEXT = "remaining connection slots are reserved";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isValidHttpStatus(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 200 && value <= 599;
+}
+
+function getNestedStatus(error: unknown): number | null {
+  if (!isRecord(error)) {
+    return null;
+  }
+
+  const status = error.status;
+  if (isValidHttpStatus(status)) {
+    return status;
+  }
+
+  const statusCode = error.statusCode;
+  if (isValidHttpStatus(statusCode)) {
+    return statusCode;
+  }
+
+  return getNestedStatus(error.cause);
+}
+
+function hasConnectionSlotError(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+
+  if (error.code === CONNECTION_SLOT_ERROR_CODE) {
+    return true;
+  }
+
+  const message = error.message;
+  if (typeof message === "string" && message.toLowerCase().includes(CONNECTION_SLOT_ERROR_TEXT)) {
+    return true;
+  }
+
+  return hasConnectionSlotError(error.cause);
+}
+
+export function toSessionErrorResponse(error: unknown): Response {
+  if (hasConnectionSlotError(error)) {
+    return new Response("Authentication temporarily unavailable", { status: 503 });
+  }
+
+  const status = getNestedStatus(error);
+  if (status === 401 || status === 403) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  return new Response("Failed to get session", {
+    status: status && status >= 500 ? status : 500,
+  });
+}


### PR DESCRIPTION
This PR stabilizes auth/session handling under load by reusing a singleton Drizzle/Postgres client per runtime instance and reducing per-instance pool size.
It adds a dedicated session error normalizer that converts Better Auth/DB failures into valid HTTP responses and maps Postgres 53300 connection-slot errors to 503.
Both authMiddleware and requireSession now catch auth.api.getSession() failures and throw normalized Response objects instead of propagating invalid status values.
I also ran bun run format, bun run lint:fix, and bun run knip.