### PR TITLE
fix(auth): handle BetterAuth getSession errors gracefully

### DIFF
--- a/src/server/middleware.ts
+++ b/src/server/middleware.ts
@@ -13,7 +13,14 @@ export const authMiddleware = createMiddleware().server(async ({ next }) => {
   const request = getRequest();
   const env = getEnv();
   const auth = createAuth(env, request);
-  const result = await auth.api.getSession({ headers: request.headers });
+
+  let result;
+  try {
+    result = await auth.api.getSession({ headers: request.headers });
+  } catch (error) {
+    console.error("auth.api.getSession threw:", error);
+    throw new Error("Unauthorized", { cause: error });
+  }
 
   if (!result) {
     throw new Error("Unauthorized");

--- a/src/server/requireSession.ts
+++ b/src/server/requireSession.ts
@@ -9,7 +9,14 @@ import { SessionContext } from "./middleware";
 export async function requireSession(request: Request): Promise<SessionContext> {
   const env = getEnv();
   const auth = createAuth(env, request);
-  const result = await auth.api.getSession({ headers: request.headers });
+
+  let result;
+  try {
+    result = await auth.api.getSession({ headers: request.headers });
+  } catch (error) {
+    console.error("auth.api.getSession threw:", error);
+    throw new Response("Unauthorized", { status: 401 });
+  }
 
   if (!result) {
     throw new Response("Unauthorized", { status: 401 });


### PR DESCRIPTION
BetterAuth wraps all internal errors from getSession in a generic "Failed to get session" message. When called from middleware or API routes, uncaught errors would propagate to clients, showing confusing error messages on the settings page. Now we catch these errors, log them for debugging, and throw a consistent "Unauthorized" error.