### PR TITLE
Warm Tauri worktree setup from main cache

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "bun i && mkdir dist && cp $CONDUCTOR_ROOT_PATH/.env .env",
+    "setup": "./scripts/setup-conductor-worktree.sh",
     "run": "bun run tauri:dev",
     "archive": "rm -rf "
   }

--- a/scripts/setup-conductor-worktree.sh
+++ b/scripts/setup-conductor-worktree.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_PATH="${CONDUCTOR_ROOT_PATH:?CONDUCTOR_ROOT_PATH is required}"
+
+copy_dir() {
+  src="$1"
+  dest="$2"
+
+  if [ ! -d "$src" ]; then
+    return
+  fi
+
+  mkdir -p "$(dirname "$dest")" "$dest"
+  rsync -a --delete "$src"/ "$dest"/
+}
+
+copy_file() {
+  src="$1"
+  dest="$2"
+
+  mkdir -p "$(dirname "$dest")"
+  cp "$src" "$dest"
+}
+
+bun install
+mkdir -p dist
+copy_file "$ROOT_PATH/.env" ".env"
+
+if [ ! -d "$ROOT_PATH/src-tauri" ]; then
+  exit 0
+fi
+
+if [ "$(git -C "$ROOT_PATH" branch --show-current)" != "main" ]; then
+  echo "Expected CONDUCTOR_ROOT_PATH to point at a main checkout: $ROOT_PATH" >&2
+  exit 1
+fi
+
+(
+  cd "$ROOT_PATH"
+  bun install
+  bun run tauri:prepare
+)
+
+copy_dir "$ROOT_PATH/.output" ".output"
+copy_dir "$ROOT_PATH/src-tauri/binaries" "src-tauri/binaries"
+copy_dir "$ROOT_PATH/src-tauri/target" "src-tauri/target"


### PR DESCRIPTION
This switches Conductor setup to a dedicated script instead of an inline command. The script builds the root checkout on main with tauri:prepare, then copies .output, src-tauri/binaries, and src-tauri/target into the worktree so tauri dev starts from warm artifacts. It still installs workspace dependencies and copies the root .env before priming the Tauri cache.