### PR TITLE
Add local OpenCode runner package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,12 @@ The local app shell should be built with `Tauri`, not as a pure PWA.
 7. Replace sandbox-only preview, callback, and background-execution assumptions with local equivalents.
 8. Add recovery and cleanup for crashed processes, stale worktrees, and port conflicts.
 
+### Migration stance
+
+- Do not spend time preserving Vercel sandbox compatibility for new runner work unless the user explicitly asks for it.
+- Prefer direct local-runner implementations and clear runner-specific contracts over temporary compatibility layers around sandbox primitives.
+- When migrating legacy sandbox code, optimize for removal and replacement rather than carrying sandbox concepts forward into new packages or APIs.
+
 ### Remote-ready constraints
 
 - Do not hardcode local-only assumptions into the domain model if they would block a remote runner later.
@@ -174,4 +180,4 @@ The local app shell should be built with `Tauri`, not as a pure PWA.
 
 - Do not introduce broad new configuration surfaces unless a concrete product need requires it.
 - Prefer direct defaults for local execution over adding feature flags for every behavior.
-- When migrating legacy sandbox code, prioritize extracting interfaces first, then swapping implementations, then renaming persisted fields where needed.
+- When migrating legacy sandbox code, prioritize runner-first replacements and only keep compatibility shims when they unblock an immediate user-facing requirement.

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@vitejs/plugin-react": "^4.3.0",
         "babel-plugin-react-compiler": "^1.0.0",
         "bun-types": "^1.3.8",
+        "concurrently": "^9.2.1",
         "drizzle-kit": "^0.31.8",
         "knip": "^5.82.1",
         "oxfmt": "^0.27.0",
@@ -50,6 +51,12 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.7.0",
         "vite": "^7.3.1",
+      },
+    },
+    "packages/runner": {
+      "name": "@clanki/runner",
+      "dependencies": {
+        "@opencode-ai/sdk": "^1.2.1",
       },
     },
   },
@@ -123,6 +130,8 @@
     "@better-auth/utils": ["@better-auth/utils@0.3.0", "", {}, "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw=="],
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
+
+    "@clanki/runner": ["@clanki/runner@workspace:packages/runner"],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260131.0", "", {}, "sha512-ELgvb2mp68Al50p+FmpgCO2hgU5o4tmz8pi7kShN+cRXc0UZoEdxpDIikR0CeT7b3tV7wlnEnsUzd0UoJLS0oQ=="],
 
@@ -864,7 +873,7 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
@@ -903,6 +912,8 @@
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
+
+    "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
@@ -1127,6 +1138,8 @@
     "h3": ["h3@2.0.1-rc.14", "", { "dependencies": { "rou3": "^0.7.12", "srvx": "^0.11.2" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-163qbGmTr/9rqQRNuqMqtgXnOUAkE4KTdauiC9y0E5iG1I65kte9NyfWvZw5RTDMt6eY+DtyoNzrQ9wA2BfvGQ=="],
 
     "h3-v2": ["h3@2.0.1-rc.14", "", { "dependencies": { "rou3": "^0.7.12", "srvx": "^0.11.2" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-163qbGmTr/9rqQRNuqMqtgXnOUAkE4KTdauiC9y0E5iG1I65kte9NyfWvZw5RTDMt6eY+DtyoNzrQ9wA2BfvGQ=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -1540,6 +1553,8 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
@@ -1563,6 +1578,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
@@ -1618,6 +1635,8 @@
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
+    "supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwind-merge": ["tailwind-merge@3.4.0", "", {}, "sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g=="],
@@ -1651,6 +1670,8 @@
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "tough-cookie": ["tough-cookie@6.0.0", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w=="],
+
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -1824,6 +1845,8 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "conventional-commits-parser/meow": ["meow@13.2.0", "", {}, "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="],
@@ -1848,11 +1871,15 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
+    "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "setup": "./scripts/setup-conductor-worktree.sh",
-    "run": "bun run tauri:dev",
+    "run": "node_modules/.bin/concurrently \"bun run runner:dev\" \"bun run tauri:dev\"",
     "archive": "rm -rf "
   }
 }

--- a/knip.json
+++ b/knip.json
@@ -3,5 +3,5 @@
   "entry": ["src/routes/**/*.{ts,tsx}", "src/lib/auth-client.ts"],
   "project": ["src/**/*.{ts,tsx}"],
   "ignore": ["src/components/ui/**", "src/routeTree.gen.ts", "src/server/db/schema.ts"],
-  "ignoreDependencies": ["tailwindcss", "shadcn", "tw-animate-css"]
+  "ignoreDependencies": ["concurrently", "tailwindcss", "shadcn", "tw-animate-css"]
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "clanki",
   "private": true,
+  "workspaces": [
+    "packages/*"
+  ],
   "type": "module",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build && tsc --noEmit",
     "preview": "vite preview",
+    "runner:dev": "bun --cwd packages/runner run dev",
     "tauri": "tauri",
     "tauri:build": "tauri build",
     "tauri:dev": "tauri dev",
@@ -59,6 +63,7 @@
     "@vitejs/plugin-react": "^4.3.0",
     "babel-plugin-react-compiler": "^1.0.0",
     "bun-types": "^1.3.8",
+    "concurrently": "^9.2.1",
     "drizzle-kit": "^0.31.8",
     "knip": "^5.82.1",
     "oxfmt": "^0.27.0",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@clanki/runner",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "dev": "bun run ./src/cli.ts"
+  },
+  "dependencies": {
+    "@opencode-ai/sdk": "^1.2.1"
+  }
+}

--- a/packages/runner/src/assistant-session.ts
+++ b/packages/runner/src/assistant-session.ts
@@ -1,0 +1,89 @@
+import { createLocalRunnerOpencodeClient } from "./opencode-client";
+import { toProviderModelRef } from "./opencode";
+
+export async function ensureAssistantSession(args: {
+  directory: string;
+  existingSessionId?: string | null;
+  model: string;
+  provider: string;
+  taskTitle: string;
+}): Promise<{ isNewSession: boolean; sessionId: string }> {
+  const { client } = await createLocalRunnerOpencodeClient({
+    directory: args.directory,
+    config: {
+      enabled_providers: [args.provider],
+      model: toProviderModelRef(args.provider, args.model),
+    },
+  });
+
+  let sessionId = args.existingSessionId?.trim() ?? "";
+  let isNewSession = false;
+
+  if (sessionId.length > 0) {
+    try {
+      const existing = await client.session.get({
+        path: { id: sessionId },
+        query: { directory: args.directory },
+      });
+      if (!existing.data) {
+        sessionId = "";
+      }
+    } catch {
+      sessionId = "";
+    }
+  }
+
+  if (sessionId.length === 0) {
+    const createResponse = await client.session.create({
+      query: { directory: args.directory },
+      body: { title: args.taskTitle },
+    });
+
+    if (!createResponse.response.ok || !createResponse.data?.id) {
+      throw new Error(formatStatusError("Failed to create OpenCode session", createResponse));
+    }
+
+    sessionId = createResponse.data.id;
+    isNewSession = true;
+  }
+
+  return { isNewSession, sessionId };
+}
+
+export async function promptAssistantSession(args: {
+  directory: string;
+  prompt: string;
+  sessionId: string;
+}): Promise<void> {
+  const { client } = await createLocalRunnerOpencodeClient({
+    directory: args.directory,
+  });
+  const promptResponse = await client.session.promptAsync({
+    path: { id: args.sessionId },
+    query: { directory: args.directory },
+    body: {
+      parts: [{ type: "text", text: args.prompt }],
+    },
+  });
+
+  if (!promptResponse.response.ok) {
+    throw new Error(
+      formatStatusError("Failed to dispatch prompt to OpenCode session", promptResponse),
+    );
+  }
+}
+
+function formatStatusError(
+  prefix: string,
+  response:
+    | { response: Response; data?: { id?: string } | null }
+    | { response: Response; data?: unknown | null },
+): string {
+  const statusText = response.response.statusText.trim();
+  const statusInfo =
+    statusText.length > 0
+      ? `${response.response.status} ${statusText}`
+      : String(response.response.status);
+
+  return `${prefix} (${statusInfo})`;
+}

--- a/packages/runner/src/cli.ts
+++ b/packages/runner/src/cli.ts
@@ -1,0 +1,39 @@
+import { startLocalRunnerServer } from "./local-runner-server";
+
+const options = parseArgs(process.argv.slice(2));
+const server = await startLocalRunnerServer(options);
+const address = server.address();
+
+if (!address || typeof address === "string") {
+  throw new Error("Failed to resolve local runner server address");
+}
+
+console.log(`Local runner listening on http://${address.address}:${address.port}`);
+
+function parseArgs(args: string[]): { host?: string; port?: number } {
+  const options: { host?: string; port?: number } = {};
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    const value = args[index + 1];
+
+    if (arg === "--host" && value) {
+      options.host = value;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--port" && value) {
+      const port = Number(value);
+      if (!Number.isInteger(port) || port <= 0) {
+        throw new Error(`Invalid port: ${value}`);
+      }
+
+      options.port = port;
+      index += 1;
+      continue;
+    }
+  }
+
+  return options;
+}

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./assistant-session";
+export * from "./local-runner-client";
+export * from "./local-runner-protocol";
+export * from "./local-runner-server";
+export * from "./opencode-models";
+export * from "./opencode";

--- a/packages/runner/src/local-runner-client.ts
+++ b/packages/runner/src/local-runner-client.ts
@@ -1,0 +1,74 @@
+import type {
+  EnsureAssistantSessionRequest,
+  EnsureAssistantSessionResponse,
+  ListOpencodeModelsRequest,
+  ListOpencodeModelsResponse,
+  LocalRunnerHealthResponse,
+  LocalRunnerInfoResponse,
+  PromptAssistantSessionRequest,
+  PromptAssistantSessionResponse,
+} from "./local-runner-protocol";
+
+export function createLocalRunnerClient(baseUrl: string) {
+  const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+
+  return {
+    async ensureAssistantSession(
+      body: EnsureAssistantSessionRequest,
+    ): Promise<EnsureAssistantSessionResponse> {
+      return await postJson(`${normalizedBaseUrl}/assistant/session/ensure`, body);
+    },
+    async health(): Promise<LocalRunnerHealthResponse> {
+      return await getJson(`${normalizedBaseUrl}/health`);
+    },
+    async info(): Promise<LocalRunnerInfoResponse> {
+      return await getJson(`${normalizedBaseUrl}/runner/info`);
+    },
+    async listOpencodeModels(
+      params: ListOpencodeModelsRequest,
+    ): Promise<ListOpencodeModelsResponse> {
+      return await getJson(
+        `${normalizedBaseUrl}/opencode/models?${new URLSearchParams({
+          directory: params.directory,
+        }).toString()}`,
+      );
+    },
+    async promptAssistantSession(
+      body: PromptAssistantSessionRequest,
+    ): Promise<PromptAssistantSessionResponse> {
+      return await postJson(`${normalizedBaseUrl}/assistant/session/prompt`, body);
+    },
+  };
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  return await parseJsonResponse<T>(response);
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  return await parseJsonResponse<T>(response);
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  const body = text.trim().length > 0 ? (JSON.parse(text) as T | { error: string }) : null;
+
+  if (!response.ok) {
+    const message =
+      body && typeof body === "object" && "error" in body && typeof body.error === "string"
+        ? body.error
+        : `${response.status} ${response.statusText}`.trim();
+    throw new Error(message);
+  }
+
+  return body as T;
+}

--- a/packages/runner/src/local-runner-protocol.ts
+++ b/packages/runner/src/local-runner-protocol.ts
@@ -1,0 +1,50 @@
+import type { ProviderListResponse } from "@opencode-ai/sdk";
+
+export const LOCAL_RUNNER_PROTOCOL_VERSION = "v1alpha1";
+
+export type LocalRunnerHealthResponse = {
+  ok: true;
+};
+
+export type LocalRunnerInfoResponse = {
+  capabilities: {
+    assistantSessions: true;
+  };
+  protocolVersion: typeof LOCAL_RUNNER_PROTOCOL_VERSION;
+  runnerType: "local-worktree";
+};
+
+export type ListOpencodeModelsRequest = {
+  directory: string;
+};
+
+export type LocalRunnerOpencodeProvider = ProviderListResponse["all"][number];
+
+export type ListOpencodeModelsResponse = {
+  connected: ProviderListResponse["connected"];
+  default: ProviderListResponse["default"];
+  providers: Array<LocalRunnerOpencodeProvider>;
+};
+
+export type EnsureAssistantSessionRequest = {
+  directory: string;
+  model: string;
+  provider: string;
+  sessionId?: string | null;
+  taskTitle: string;
+};
+
+export type EnsureAssistantSessionResponse = {
+  isNewSession: boolean;
+  sessionId: string;
+};
+
+export type PromptAssistantSessionRequest = {
+  directory: string;
+  prompt: string;
+  sessionId: string;
+};
+
+export type PromptAssistantSessionResponse = {
+  ok: true;
+};

--- a/packages/runner/src/local-runner-server.ts
+++ b/packages/runner/src/local-runner-server.ts
@@ -1,0 +1,136 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { ensureAssistantSession, promptAssistantSession } from "./assistant-session";
+import {
+  LOCAL_RUNNER_PROTOCOL_VERSION,
+  type EnsureAssistantSessionRequest,
+  type ListOpencodeModelsRequest,
+  type PromptAssistantSessionRequest,
+} from "./local-runner-protocol";
+import { listOpencodeModels } from "./opencode-models";
+
+export type LocalRunnerServerOptions = {
+  host?: string;
+  port?: number;
+};
+
+class RequestError extends Error {
+  constructor(
+    message: string,
+    readonly statusCode: number = 400,
+  ) {
+    super(message);
+  }
+}
+
+export function startLocalRunnerServer(options?: LocalRunnerServerOptions): Promise<Server> {
+  const host = options?.host ?? "127.0.0.1";
+  const port = options?.port ?? 4318;
+
+  const server = createServer(async (request, response) => {
+    try {
+      await routeRequest(request, response);
+    } catch (error) {
+      sendJson(response, error instanceof RequestError ? error.statusCode : 500, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolve(server);
+    });
+  });
+}
+
+async function routeRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+  const method = request.method?.toUpperCase() ?? "GET";
+  const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+  const pathname = requestUrl.pathname;
+
+  if (method === "GET" && pathname === "/health") {
+    sendJson(response, 200, { ok: true });
+    return;
+  }
+
+  if (method === "GET" && pathname === "/runner/info") {
+    sendJson(response, 200, {
+      capabilities: {
+        assistantSessions: true,
+      },
+      protocolVersion: LOCAL_RUNNER_PROTOCOL_VERSION,
+      runnerType: "local-worktree",
+    });
+    return;
+  }
+
+  if (method === "GET" && pathname === "/opencode/models") {
+    const directory = readDirectoryQuery(requestUrl);
+    sendJson(
+      response,
+      200,
+      await listOpencodeModels({
+        directory,
+      } satisfies ListOpencodeModelsRequest),
+    );
+    return;
+  }
+
+  if (method === "POST" && pathname === "/assistant/session/ensure") {
+    const body = await readJson<EnsureAssistantSessionRequest>(request);
+    sendJson(
+      response,
+      200,
+      await ensureAssistantSession({
+        directory: body.directory,
+        existingSessionId: body.sessionId,
+        model: body.model,
+        provider: body.provider,
+        taskTitle: body.taskTitle,
+      }),
+    );
+    return;
+  }
+
+  if (method === "POST" && pathname === "/assistant/session/prompt") {
+    const body = await readJson<PromptAssistantSessionRequest>(request);
+    await promptAssistantSession(body);
+    sendJson(response, 200, { ok: true });
+    return;
+  }
+
+  sendJson(response, 404, { error: `Unknown route: ${method} ${pathname}` });
+}
+
+async function readJson<T>(request: IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  const body = Buffer.concat(chunks).toString("utf8").trim();
+  if (body.length === 0) {
+    throw new Error("Expected JSON request body");
+  }
+
+  return JSON.parse(body) as T;
+}
+
+function sendJson(response: ServerResponse, statusCode: number, body: unknown): void {
+  response.writeHead(statusCode, {
+    "Content-Type": "application/json",
+  });
+  response.end(JSON.stringify(body));
+}
+
+function readDirectoryQuery(requestUrl: URL): string {
+  const directory = requestUrl.searchParams.get("directory")?.trim() ?? "";
+  if (directory.length === 0) {
+    throw new RequestError("directory query parameter is required");
+  }
+
+  return directory;
+}

--- a/packages/runner/src/opencode-client.ts
+++ b/packages/runner/src/opencode-client.ts
@@ -1,0 +1,17 @@
+import { createOpencodeClient, type Config } from "@opencode-ai/sdk";
+import { ensureLocalOpencodeServer } from "./opencode-server";
+
+export async function createLocalRunnerOpencodeClient(args: {
+  directory: string;
+  config?: Config;
+}) {
+  const server = await ensureLocalOpencodeServer(args.config);
+
+  return {
+    client: createOpencodeClient({
+      baseUrl: server.baseUrl,
+      directory: args.directory,
+    }),
+    server,
+  };
+}

--- a/packages/runner/src/opencode-models.ts
+++ b/packages/runner/src/opencode-models.ts
@@ -1,0 +1,39 @@
+import { createLocalRunnerOpencodeClient } from "./opencode-client";
+import type { ListOpencodeModelsResponse } from "./local-runner-protocol";
+
+export async function listOpencodeModels(args: {
+  directory: string;
+}): Promise<ListOpencodeModelsResponse> {
+  const directory = args.directory.trim();
+  if (directory.length === 0) {
+    throw new Error("directory is required");
+  }
+
+  const { client } = await createLocalRunnerOpencodeClient({ directory });
+  const providerListResponse = await client.provider.list({
+    query: { directory },
+  });
+
+  if (!providerListResponse.response.ok) {
+    throw new Error(formatStatusError("Failed to list OpenCode models", providerListResponse));
+  }
+
+  return {
+    connected: providerListResponse.data?.connected ?? [],
+    default: providerListResponse.data?.default ?? {},
+    providers: providerListResponse.data?.all ?? [],
+  };
+}
+
+function formatStatusError(
+  prefix: string,
+  response: { response: Response; data?: unknown | null },
+): string {
+  const statusText = response.response.statusText.trim();
+  const statusInfo =
+    statusText.length > 0
+      ? `${response.response.status} ${statusText}`
+      : String(response.response.status);
+
+  return `${prefix} (${statusInfo})`;
+}

--- a/packages/runner/src/opencode-server.ts
+++ b/packages/runner/src/opencode-server.ts
@@ -1,0 +1,108 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
+import type { Config } from "@opencode-ai/sdk";
+
+const DEFAULT_HOST = "127.0.0.1";
+const DEFAULT_PORT = 4096;
+const READY_RETRY_COUNT = 30;
+const READY_RETRY_DELAY_MS = 500;
+
+type OpencodeServerState = {
+  child: ChildProcessWithoutNullStreams | null;
+  host: string;
+  port: number;
+  configKey: string;
+};
+
+const serverState: OpencodeServerState = {
+  child: null,
+  host: DEFAULT_HOST,
+  port: DEFAULT_PORT,
+  configKey: "",
+};
+
+export type LocalOpencodeServer = {
+  baseUrl: string;
+  host: string;
+  pid: number | null;
+  port: number;
+};
+
+export async function ensureLocalOpencodeServer(config?: Config): Promise<LocalOpencodeServer> {
+  const configKey = JSON.stringify(config ?? {});
+  if (
+    serverState.configKey === configKey &&
+    (await isOpencodeServerReady(serverState.host, serverState.port))
+  ) {
+    serverState.configKey = configKey;
+    return toLocalOpencodeServer();
+  }
+
+  if (serverState.child && !serverState.child.killed) {
+    serverState.child.kill("SIGTERM");
+    serverState.child = null;
+  }
+
+  serverState.child = spawn(
+    "opencode",
+    ["serve", "--hostname", serverState.host, "--port", String(serverState.port)],
+    {
+      env: {
+        ...process.env,
+        OPENCODE_CONFIG_CONTENT: JSON.stringify(config ?? {}),
+      },
+      stdio: "pipe",
+    },
+  );
+  serverState.configKey = configKey;
+
+  serverState.child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+  });
+
+  serverState.child.stdout.on("data", (chunk) => {
+    process.stdout.write(chunk);
+  });
+
+  serverState.child.once("exit", () => {
+    serverState.child = null;
+  });
+
+  for (let attempt = 0; attempt < READY_RETRY_COUNT; attempt++) {
+    if (await isOpencodeServerReady(serverState.host, serverState.port)) {
+      return toLocalOpencodeServer();
+    }
+
+    await sleep(READY_RETRY_DELAY_MS);
+  }
+
+  throw new Error("Timed out waiting for the local OpenCode server to become ready");
+}
+
+async function isOpencodeServerReady(host: string, port: number): Promise<boolean> {
+  try {
+    const response = await fetch(`http://${host}:${port}/session/status`);
+    if (!response.ok) {
+      return false;
+    }
+
+    const body = (await response.text()).trim();
+    if (body.length === 0) {
+      return false;
+    }
+
+    const parsed = JSON.parse(body) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
+  } catch {
+    return false;
+  }
+}
+
+function toLocalOpencodeServer(): LocalOpencodeServer {
+  return {
+    baseUrl: `http://${serverState.host}:${serverState.port}`,
+    host: serverState.host,
+    pid: serverState.child?.pid ?? null,
+    port: serverState.port,
+  };
+}

--- a/packages/runner/src/opencode.ts
+++ b/packages/runner/src/opencode.ts
@@ -1,0 +1,14 @@
+export const DEFAULT_OPENCODE_PROVIDER = "openai";
+export const DEFAULT_OPENCODE_MODEL = "gpt-5.3-codex";
+
+export const SUPPORTED_OPENCODE_PROVIDERS = [DEFAULT_OPENCODE_PROVIDER] as const;
+
+export type SupportedOpencodeProvider = (typeof SUPPORTED_OPENCODE_PROVIDERS)[number];
+
+export function isSupportedOpencodeProvider(value: string): value is SupportedOpencodeProvider {
+  return SUPPORTED_OPENCODE_PROVIDERS.includes(value as SupportedOpencodeProvider);
+}
+
+export function toProviderModelRef(provider: string, model: string): string {
+  return `${provider}/${model}`;
+}

--- a/packages/runner/tsconfig.json
+++ b/packages/runner/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "compilerOptions": {
+    "types": ["bun-types"]
+  }
+}


### PR DESCRIPTION
## Summary
- add a new @clanki/runner workspace package with a local HTTP runner server, typed client/protocol helpers, OpenCode session management, and an endpoint to list available OpenCode models
- wire the repo up for the new package by enabling workspaces, adding runner:dev, and running the Conductor app with the runner and Tauri dev processes together
- update lockfile/knip metadata for the new workspace dependency and tighten AGENTS.md guidance toward direct local-runner migration work
