### PR TITLE
Refactor desktop runner calls into JS

### DIFF
--- a/packages/runner/src/local-runner-server.ts
+++ b/packages/runner/src/local-runner-server.ts
@@ -52,6 +52,11 @@ async function routeRequest(request: IncomingMessage, response: ServerResponse):
   const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
   const pathname = requestUrl.pathname;
 
+  if (method === "OPTIONS") {
+    sendNoContent(response);
+    return;
+  }
+
   if (method === "GET" && pathname === "/health") {
     sendJson(response, 200, { ok: true });
     return;
@@ -132,10 +137,23 @@ async function readJson<T>(request: IncomingMessage): Promise<T> {
 }
 
 function sendJson(response: ServerResponse, statusCode: number, body: unknown): void {
+  setCorsHeaders(response);
   response.writeHead(statusCode, {
     "Content-Type": "application/json",
   });
   response.end(JSON.stringify(body));
+}
+
+function sendNoContent(response: ServerResponse): void {
+  setCorsHeaders(response);
+  response.writeHead(204);
+  response.end();
+}
+
+function setCorsHeaders(response: ServerResponse): void {
+  response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  response.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  response.setHeader("Access-Control-Allow-Origin", "*");
 }
 
 function readDirectoryQuery(requestUrl: URL): string {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
-use reqwest::blocking::{Client, Response};
-use serde::{Deserialize, Serialize};
+use reqwest::blocking::Client;
+use serde::Serialize;
 use std::{
     error::Error,
     net::{TcpListener, TcpStream},
@@ -14,9 +14,6 @@ use tauri_plugin_shell::process::CommandChild;
 
 #[cfg(not(debug_assertions))]
 use tauri_plugin_shell::ShellExt;
-
-const DEFAULT_OPENCODE_MODEL: &str = "gpt-5.3-codex";
-const DEFAULT_OPENCODE_PROVIDER: &str = "openai";
 
 struct ServerProcess(Mutex<Option<CommandChild>>);
 struct RunnerProcess(Mutex<Option<RunnerInstance>>);
@@ -33,53 +30,11 @@ struct RunnerConnection {
     workspace_directory: String,
 }
 
-#[derive(Deserialize, Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-struct RunnerSessionSummary {
-    created_at: u64,
-    directory: String,
-    id: String,
-    title: String,
-    updated_at: u64,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ListAssistantSessionsResponse {
-    sessions: Vec<RunnerSessionSummary>,
-}
-
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct RunnerSessionsPayload {
-    sessions: Vec<RunnerSessionSummary>,
+struct RunnerConnectionPayload {
+    base_url: String,
     workspace_directory: String,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct CreateRunnerSessionResponse {
-    session_id: String,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct EnsureAssistantSessionRequest {
-    directory: String,
-    model: String,
-    provider: String,
-    task_title: String,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct EnsureAssistantSessionResponse {
-    session_id: String,
-}
-
-#[derive(Deserialize)]
-struct RunnerErrorResponse {
-    error: String,
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -88,10 +43,7 @@ pub fn run() {
         .manage(ServerProcess(Mutex::new(None)))
         .manage(RunnerProcess(Mutex::new(None)))
         .plugin(tauri_plugin_shell::init())
-        .invoke_handler(tauri::generate_handler![
-            create_runner_session,
-            list_runner_sessions
-        ])
+        .invoke_handler(tauri::generate_handler![ensure_runner_connection])
         .setup(|app| {
             let app_url = resolve_app_url(app.handle())?;
 
@@ -124,52 +76,15 @@ pub fn run() {
 }
 
 #[tauri::command]
-fn list_runner_sessions(
+fn ensure_runner_connection(
     app: AppHandle,
     runner_process: State<'_, RunnerProcess>,
-) -> Result<RunnerSessionsPayload, String> {
+) -> Result<RunnerConnectionPayload, String> {
     let runner = ensure_runner(&app, runner_process.inner())?;
-    let client = runner_http_client()?;
-    let response = client
-        .get(format!("{}/assistant/sessions", runner.base_url))
-        .query(&[("directory", runner.workspace_directory.as_str())])
-        .send()
-        .map_err(|error| format!("Failed to reach local runner: {error}"))?;
-    let payload: ListAssistantSessionsResponse = parse_runner_json(response)?;
 
-    Ok(RunnerSessionsPayload {
-        sessions: payload.sessions,
+    Ok(RunnerConnectionPayload {
+        base_url: runner.base_url,
         workspace_directory: runner.workspace_directory,
-    })
-}
-
-#[tauri::command]
-fn create_runner_session(
-    app: AppHandle,
-    runner_process: State<'_, RunnerProcess>,
-    title: String,
-) -> Result<CreateRunnerSessionResponse, String> {
-    let trimmed_title = title.trim();
-    if trimmed_title.is_empty() {
-        return Err("title is required".to_string());
-    }
-
-    let runner = ensure_runner(&app, runner_process.inner())?;
-    let client = runner_http_client()?;
-    let response = client
-        .post(format!("{}/assistant/session/ensure", runner.base_url))
-        .json(&EnsureAssistantSessionRequest {
-            directory: runner.workspace_directory.clone(),
-            model: DEFAULT_OPENCODE_MODEL.to_string(),
-            provider: DEFAULT_OPENCODE_PROVIDER.to_string(),
-            task_title: trimmed_title.to_string(),
-        })
-        .send()
-        .map_err(|error| format!("Failed to reach local runner: {error}"))?;
-    let payload: EnsureAssistantSessionResponse = parse_runner_json(response)?;
-
-    Ok(CreateRunnerSessionResponse {
-        session_id: payload.session_id,
     })
 }
 
@@ -275,24 +190,6 @@ fn runner_http_client() -> Result<Client, String> {
         .timeout(Duration::from_secs(30))
         .build()
         .map_err(|error| format!("Failed to create runner HTTP client: {error}"))
-}
-
-fn parse_runner_json<T: for<'de> Deserialize<'de>>(response: Response) -> Result<T, String> {
-    let status = response.status();
-
-    if status.is_success() {
-        return response
-            .json::<T>()
-            .map_err(|error| format!("Failed to decode runner response: {error}"));
-    }
-
-    let message = match response.json::<RunnerErrorResponse>() {
-        Ok(body) if !body.error.trim().is_empty() => body.error,
-        Ok(_) => format!("Runner request failed with status {status}"),
-        Err(_) => format!("Runner request failed with status {status}"),
-    };
-
-    Err(message)
 }
 
 #[cfg(debug_assertions)]

--- a/src/lib/desktop-runner.ts
+++ b/src/lib/desktop-runner.ts
@@ -1,10 +1,33 @@
 import { invoke } from "@tauri-apps/api/core";
-import type { RunnerSessionsPayload } from "@/shared/runner-session";
+import { createLocalRunnerClient } from "@/lib/local-runner-client";
+import type { RunnerConnectionPayload, RunnerSessionsPayload } from "@/shared/runner-session";
+
+const DEFAULT_OPENCODE_MODEL = "gpt-5.3-codex";
+const DEFAULT_OPENCODE_PROVIDER = "openai";
+
+async function ensureDesktopRunnerConnection(): Promise<RunnerConnectionPayload> {
+  return await invoke<RunnerConnectionPayload>("ensure_runner_connection");
+}
 
 export async function listDesktopRunnerSessions(): Promise<RunnerSessionsPayload> {
-  return await invoke<RunnerSessionsPayload>("list_runner_sessions");
+  const connection = await ensureDesktopRunnerConnection();
+  const client = createLocalRunnerClient(connection);
+  const response = await client.listAssistantSessions();
+
+  return {
+    sessions: response.sessions,
+    workspaceDirectory: connection.workspaceDirectory,
+  };
 }
 
 export async function createDesktopRunnerSession(title: string): Promise<{ sessionId: string }> {
-  return await invoke<{ sessionId: string }>("create_runner_session", { title });
+  const connection = await ensureDesktopRunnerConnection();
+  const client = createLocalRunnerClient(connection);
+  const response = await client.ensureAssistantSession({
+    model: DEFAULT_OPENCODE_MODEL,
+    provider: DEFAULT_OPENCODE_PROVIDER,
+    taskTitle: title,
+  });
+
+  return { sessionId: response.sessionId };
 }

--- a/src/lib/local-runner-client.ts
+++ b/src/lib/local-runner-client.ts
@@ -1,0 +1,62 @@
+import type {
+  EnsureAssistantSessionRequest,
+  EnsureAssistantSessionResponse,
+  ListAssistantSessionsResponse,
+} from "@/shared/local-runner";
+import type { RunnerConnectionPayload } from "@/shared/runner-session";
+
+export function createLocalRunnerClient(connection: RunnerConnectionPayload) {
+  const baseUrl = connection.baseUrl.endsWith("/")
+    ? connection.baseUrl.slice(0, -1)
+    : connection.baseUrl;
+
+  return {
+    async ensureAssistantSession(
+      body: Omit<EnsureAssistantSessionRequest, "directory">,
+    ): Promise<EnsureAssistantSessionResponse> {
+      return await postJson<EnsureAssistantSessionResponse>(`${baseUrl}/assistant/session/ensure`, {
+        ...body,
+        directory: connection.workspaceDirectory,
+      } satisfies EnsureAssistantSessionRequest);
+    },
+    async listAssistantSessions(): Promise<ListAssistantSessionsResponse> {
+      return await getJson<ListAssistantSessionsResponse>(
+        `${baseUrl}/assistant/sessions?${new URLSearchParams({
+          directory: connection.workspaceDirectory,
+        }).toString()}`,
+      );
+    },
+  };
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  return await parseJsonResponse<T>(response);
+}
+
+async function postJson<T>(url: string, body: unknown): Promise<T> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  return await parseJsonResponse<T>(response);
+}
+
+async function parseJsonResponse<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  const body = text.trim().length > 0 ? (JSON.parse(text) as T | { error: string }) : null;
+
+  if (!response.ok) {
+    const message =
+      body && typeof body === "object" && "error" in body && typeof body.error === "string"
+        ? body.error
+        : `${response.status} ${response.statusText}`.trim();
+    throw new Error(message);
+  }
+
+  return body as T;
+}

--- a/src/shared/local-runner.ts
+++ b/src/shared/local-runner.ts
@@ -1,0 +1,18 @@
+import type { RunnerSessionSummary } from "@/shared/runner-session";
+
+export type EnsureAssistantSessionRequest = {
+  directory: string;
+  model: string;
+  provider: string;
+  sessionId?: string | null;
+  taskTitle: string;
+};
+
+export type EnsureAssistantSessionResponse = {
+  isNewSession: boolean;
+  sessionId: string;
+};
+
+export type ListAssistantSessionsResponse = {
+  sessions: RunnerSessionSummary[];
+};

--- a/src/shared/runner-session.ts
+++ b/src/shared/runner-session.ts
@@ -6,6 +6,11 @@ export type RunnerSessionSummary = {
   updatedAt: number;
 };
 
+export type RunnerConnectionPayload = {
+  baseUrl: string;
+  workspaceDirectory: string;
+};
+
 export type RunnerSessionsPayload = {
   sessions: RunnerSessionSummary[];
   workspaceDirectory: string;


### PR DESCRIPTION
Move desktop runner session requests out of the Tauri Rust proxy and into the frontend so Rust only ensures the local runner is running and returns its connection info. Add a small frontend localhost runner client plus shared protocol types, and update the runner HTTP server to handle CORS and OPTIONS preflight for webview fetches. Validation run: bun run format, bun run lint:fix, bun run knip, bun run build, and cargo check --manifest-path src-tauri/Cargo.toml.