### PR TITLE
Use managed repo worktrees for runner sessions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,13 +1,16 @@
 use reqwest::blocking::Client;
 use serde::Serialize;
 use std::{
+    collections::HashSet,
+    env,
     error::Error,
+    fs,
     net::{TcpListener, TcpStream},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
     sync::Mutex,
     thread::sleep,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tauri::{webview::WebviewWindowBuilder, AppHandle, Manager, RunEvent, State, WebviewUrl};
 use tauri_plugin_shell::process::CommandChild;
@@ -21,13 +24,22 @@ struct RunnerProcess(Mutex<Option<RunnerInstance>>);
 struct RunnerInstance {
     base_url: String,
     child: Child,
-    workspace_directory: String,
 }
 
 #[derive(Clone)]
 struct RunnerConnection {
     base_url: String,
-    workspace_directory: String,
+}
+
+struct RepoWorkspacePaths {
+    default_directory: PathBuf,
+    repo_root: PathBuf,
+}
+
+struct PreparedWorktree {
+    branch_name: String,
+    directory: PathBuf,
+    default_directory: PathBuf,
 }
 
 #[derive(Serialize)]
@@ -79,15 +91,56 @@ pub fn run() {
 fn ensure_runner_connection(
     app: AppHandle,
     runner_process: State<'_, RunnerProcess>,
-) -> Result<RunnerConnectionPayload, String> {
+    repo_url: String,
+) -> Result<RunnerSessionsPayload, String> {
     let runner = ensure_runner(&app, runner_process.inner())?;
+    let workspace = resolve_repo_workspace_paths(&repo_url)?;
+    let client = runner_http_client()?;
+    let sessions = list_repo_sessions(&client, &runner, &workspace.repo_root)?;
 
-    Ok(RunnerConnectionPayload {
-        base_url: runner.base_url,
-        workspace_directory: runner.workspace_directory,
+    Ok(RunnerSessionsPayload {
+        sessions,
+        workspace_directory: workspace.repo_root.display().to_string(),
     })
 }
 
+#[tauri::command]
+fn create_runner_session(
+    app: AppHandle,
+    runner_process: State<'_, RunnerProcess>,
+    repo_url: String,
+    title: String,
+) -> Result<CreateRunnerSessionResponse, String> {
+    let trimmed_title = title.trim();
+    if trimmed_title.is_empty() {
+        return Err("title is required".to_string());
+    }
+
+    let runner = ensure_runner(&app, runner_process.inner())?;
+    let worktree = prepare_session_worktree(&repo_url, trimmed_title)?;
+    let client = runner_http_client()?;
+    let response = client
+        .post(format!("{}/assistant/session/ensure", runner.base_url))
+        .json(&EnsureAssistantSessionRequest {
+            directory: worktree.directory.display().to_string(),
+            model: DEFAULT_OPENCODE_MODEL.to_string(),
+            provider: DEFAULT_OPENCODE_PROVIDER.to_string(),
+            task_title: trimmed_title.to_string(),
+        })
+        .send()
+        .map_err(|error| format!("Failed to reach local runner: {error}"))?;
+    let payload: EnsureAssistantSessionResponse = match parse_runner_json(response) {
+        Ok(payload) => payload,
+        Err(error) => {
+            cleanup_failed_worktree(&worktree);
+            return Err(error);
+        }
+    };
+
+    Ok(CreateRunnerSessionResponse {
+        session_id: payload.session_id,
+    })
+}
 fn ensure_runner(
     app: &AppHandle,
     runner_process: &RunnerProcess,
@@ -107,7 +160,6 @@ fn current_runner_connection(runner_process: &RunnerProcess) -> Option<RunnerCon
     let process = runner_process.0.lock().expect("runner process lock");
     process.as_ref().map(|runner| RunnerConnection {
         base_url: runner.base_url.clone(),
-        workspace_directory: runner.workspace_directory.clone(),
     })
 }
 
@@ -116,7 +168,6 @@ fn start_runner(
     runner_process: &RunnerProcess,
 ) -> Result<RunnerConnection, String> {
     let workspace_root = resolve_workspace_root(app)?;
-    let workspace_directory = workspace_root.display().to_string();
     let runner_entry = workspace_root.join("packages/runner/src/cli.ts");
 
     if !runner_entry.exists() {
@@ -147,15 +198,10 @@ fn start_runner(
     let base_url = format!("http://127.0.0.1:{port}");
     let connection = RunnerConnection {
         base_url: base_url.clone(),
-        workspace_directory: workspace_directory.clone(),
     };
 
     let mut process = runner_process.0.lock().expect("runner process lock");
-    *process = Some(RunnerInstance {
-        base_url,
-        child,
-        workspace_directory,
-    });
+    *process = Some(RunnerInstance { base_url, child });
 
     Ok(connection)
 }
@@ -169,6 +215,406 @@ fn stop_runner(runner_process: &RunnerProcess) {
     if let Some(mut runner) = runner {
         let _ = runner.child.kill();
         let _ = runner.child.wait();
+    }
+}
+
+fn list_repo_sessions(
+    client: &Client,
+    runner: &RunnerConnection,
+    repo_root: &Path,
+) -> Result<Vec<RunnerSessionSummary>, String> {
+    let workspace_directories = list_workspace_directories(repo_root)?;
+    let mut sessions = Vec::new();
+    let mut seen_session_ids = HashSet::new();
+
+    for directory in workspace_directories {
+        let directory_string = directory.display().to_string();
+        let response = client
+            .get(format!("{}/assistant/sessions", runner.base_url))
+            .query(&[("directory", directory_string.as_str())])
+            .send()
+            .map_err(|error| format!("Failed to reach local runner: {error}"))?;
+        let payload: ListAssistantSessionsResponse = parse_runner_json(response)?;
+
+        for session in payload.sessions {
+            if seen_session_ids.insert(session.id.clone()) {
+                sessions.push(session);
+            }
+        }
+    }
+
+    sessions.sort_by(|left, right| {
+        right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then(right.created_at.cmp(&left.created_at))
+    });
+
+    Ok(sessions)
+}
+
+fn list_workspace_directories(repo_root: &Path) -> Result<Vec<PathBuf>, String> {
+    if !repo_root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut directories = Vec::new();
+
+    for entry in fs::read_dir(repo_root).map_err(|error| {
+        format!(
+            "Failed to read workspace directory {}: {error}",
+            repo_root.display()
+        )
+    })? {
+        let entry = entry.map_err(|error| {
+            format!(
+                "Failed to read a workspace entry in {}: {error}",
+                repo_root.display()
+            )
+        })?;
+        let path = entry.path();
+
+        if !path.is_dir() {
+            continue;
+        }
+
+        if path.join(".git").exists() {
+            directories.push(path);
+        }
+    }
+
+    directories.sort();
+    Ok(directories)
+}
+
+fn prepare_session_worktree(repo_url: &str, title: &str) -> Result<PreparedWorktree, String> {
+    let workspace = resolve_repo_workspace_paths(repo_url)?;
+    let default_branch = ensure_default_checkout(repo_url, &workspace)?;
+    let identifier = next_worktree_identifier(&workspace.repo_root, title)?;
+    let directory = workspace.repo_root.join(&identifier);
+    let branch_name = format!("runner/{identifier}");
+
+    run_command(
+        "git",
+        &[
+            "-C",
+            &workspace.default_directory.display().to_string(),
+            "worktree",
+            "add",
+            "-b",
+            &branch_name,
+            &directory.display().to_string(),
+            &default_branch,
+        ],
+        Some(format!(
+            "Failed to create a worktree at {}",
+            directory.display()
+        )),
+    )?;
+
+    Ok(PreparedWorktree {
+        branch_name,
+        directory,
+        default_directory: workspace.default_directory,
+    })
+}
+
+fn cleanup_failed_worktree(worktree: &PreparedWorktree) {
+    let _ = run_command(
+        "git",
+        &[
+            "-C",
+            &worktree.default_directory.display().to_string(),
+            "worktree",
+            "remove",
+            "--force",
+            &worktree.directory.display().to_string(),
+        ],
+        None,
+    );
+    let _ = run_command(
+        "git",
+        &[
+            "-C",
+            &worktree.default_directory.display().to_string(),
+            "branch",
+            "-D",
+            &worktree.branch_name,
+        ],
+        None,
+    );
+}
+
+fn ensure_default_checkout(
+    repo_url: &str,
+    workspace: &RepoWorkspacePaths,
+) -> Result<String, String> {
+    fs::create_dir_all(&workspace.repo_root).map_err(|error| {
+        format!(
+            "Failed to create workspace root {}: {error}",
+            workspace.repo_root.display()
+        )
+    })?;
+
+    if !workspace.default_directory.exists() {
+        clone_default_checkout(repo_url, &workspace.default_directory)?;
+    } else if !workspace.default_directory.join(".git").exists() {
+        return Err(format!(
+            "Managed checkout exists without git metadata: {}",
+            workspace.default_directory.display()
+        ));
+    }
+
+    run_command(
+        "git",
+        &[
+            "-C",
+            &workspace.default_directory.display().to_string(),
+            "fetch",
+            "origin",
+            "--prune",
+        ],
+        Some(format!(
+            "Failed to fetch the default checkout in {}",
+            workspace.default_directory.display()
+        )),
+    )?;
+
+    let default_branch = resolve_default_branch(&workspace.default_directory)?;
+
+    run_command(
+        "git",
+        &[
+            "-C",
+            &workspace.default_directory.display().to_string(),
+            "checkout",
+            &default_branch,
+        ],
+        Some(format!(
+            "Failed to checkout {default_branch} in {}",
+            workspace.default_directory.display()
+        )),
+    )?;
+
+    run_command(
+        "git",
+        &[
+            "-C",
+            &workspace.default_directory.display().to_string(),
+            "pull",
+            "--ff-only",
+            "origin",
+            &default_branch,
+        ],
+        Some(format!(
+            "Failed to fast-forward {default_branch} in {}",
+            workspace.default_directory.display()
+        )),
+    )?;
+
+    Ok(default_branch)
+}
+
+fn clone_default_checkout(repo_url: &str, default_directory: &Path) -> Result<(), String> {
+    if let Some(parent_directory) = default_directory.parent() {
+        fs::create_dir_all(parent_directory).map_err(|error| {
+            format!(
+                "Failed to create clone parent directory {}: {error}",
+                parent_directory.display()
+            )
+        })?;
+    }
+
+    let repo_slug = parse_repo_slug(repo_url)?;
+    run_command(
+        "gh",
+        &[
+            "repo",
+            "clone",
+            &repo_slug,
+            &default_directory.display().to_string(),
+        ],
+        Some(format!(
+            "Failed to clone {repo_slug} into {}",
+            default_directory.display()
+        )),
+    )?;
+
+    Ok(())
+}
+
+fn resolve_default_branch(default_directory: &Path) -> Result<String, String> {
+    let output = run_command(
+        "git",
+        &[
+            "-C",
+            &default_directory.display().to_string(),
+            "symbolic-ref",
+            "--short",
+            "refs/remotes/origin/HEAD",
+        ],
+        Some(format!(
+            "Failed to resolve the default branch for {}",
+            default_directory.display()
+        )),
+    )?;
+    let reference = output.trim();
+    let branch_name = reference
+        .strip_prefix("origin/")
+        .unwrap_or(reference)
+        .trim()
+        .to_string();
+
+    if branch_name.is_empty() {
+        return Err(format!(
+            "Failed to resolve the default branch for {}",
+            default_directory.display()
+        ));
+    }
+
+    Ok(branch_name)
+}
+
+fn next_worktree_identifier(repo_root: &Path, title: &str) -> Result<String, String> {
+    let title_slug = slugify_identifier(title);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| format!("Failed to build a worktree identifier: {error}"))?
+        .as_secs();
+
+    for attempt in 0..100 {
+        let identifier = if attempt == 0 {
+            format!("{timestamp}-{title_slug}")
+        } else {
+            format!("{timestamp}-{title_slug}-{attempt}")
+        };
+
+        if !repo_root.join(&identifier).exists() {
+            return Ok(identifier);
+        }
+    }
+
+    Err(format!(
+        "Failed to allocate a unique worktree directory in {}",
+        repo_root.display()
+    ))
+}
+
+fn slugify_identifier(value: &str) -> String {
+    let mut slug = String::new();
+    let mut last_was_separator = false;
+
+    for character in value.chars() {
+        if character.is_ascii_alphanumeric() {
+            slug.push(character.to_ascii_lowercase());
+            last_was_separator = false;
+            continue;
+        }
+
+        if !last_was_separator {
+            slug.push('-');
+            last_was_separator = true;
+        }
+    }
+
+    let trimmed = slug.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "session".to_string()
+    } else {
+        trimmed
+    }
+}
+
+fn resolve_repo_workspace_paths(repo_url: &str) -> Result<RepoWorkspacePaths, String> {
+    let repo_name = parse_repo_name(repo_url)?;
+    let repo_root = resolve_runner_root()?.join(repo_name);
+
+    Ok(RepoWorkspacePaths {
+        default_directory: repo_root.join("default"),
+        repo_root,
+    })
+}
+
+fn resolve_runner_root() -> Result<PathBuf, String> {
+    let home_directory = env::var_os("HOME")
+        .map(PathBuf::from)
+        .ok_or_else(|| "Failed to resolve the user's home directory".to_string())?;
+
+    Ok(home_directory.join("clanki"))
+}
+
+fn parse_repo_slug(repo_url: &str) -> Result<String, String> {
+    let normalized = normalize_repo_reference(repo_url);
+    let repo_path = if let Some(path) = normalized.strip_prefix("https://github.com/") {
+        path
+    } else if let Some(path) = normalized.strip_prefix("git@github.com:") {
+        path
+    } else if let Some(path) = normalized.strip_prefix("ssh://git@github.com/") {
+        path
+    } else {
+        normalized.as_str()
+    };
+
+    let segments: Vec<&str> = repo_path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    if segments.len() != 2 {
+        return Err(format!("Unsupported GitHub repository URL: {repo_url}"));
+    }
+
+    Ok(format!("{}/{}", segments[0], segments[1]))
+}
+
+fn parse_repo_name(repo_url: &str) -> Result<String, String> {
+    let repo_slug = parse_repo_slug(repo_url)?;
+    repo_slug
+        .split('/')
+        .nth(1)
+        .map(ToString::to_string)
+        .ok_or_else(|| format!("Unsupported GitHub repository URL: {repo_url}"))
+}
+
+fn normalize_repo_reference(repo_url: &str) -> String {
+    repo_url
+        .trim()
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .to_string()
+}
+
+fn run_command(
+    program: &str,
+    args: &[&str],
+    error_context: Option<String>,
+) -> Result<String, String> {
+    let output = Command::new(program)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|error| match &error_context {
+            Some(context) => format!("{context}: {error}"),
+            None => format!("Failed to run {program}: {error}"),
+        })?;
+
+    if output.status.success() {
+        return Ok(String::from_utf8_lossy(&output.stdout).to_string());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let details = if !stderr.is_empty() {
+        stderr
+    } else if !stdout.is_empty() {
+        stdout
+    } else {
+        format!("exit status {}", output.status)
+    };
+
+    match error_context {
+        Some(context) => Err(format!("{context}: {details}")),
+        None => Err(format!("Command {program} failed: {details}")),
     }
 }
 

--- a/src/lib/desktop-runner.ts
+++ b/src/lib/desktop-runner.ts
@@ -1,33 +1,16 @@
 import { invoke } from "@tauri-apps/api/core";
-import { createLocalRunnerClient } from "@/lib/local-runner-client";
-import type { RunnerConnectionPayload, RunnerSessionsPayload } from "@/shared/runner-session";
+import type { RunnerSessionsPayload } from "@/shared/runner-session";
 
-const DEFAULT_OPENCODE_MODEL = "gpt-5.3-codex";
-const DEFAULT_OPENCODE_PROVIDER = "openai";
-
-async function ensureDesktopRunnerConnection(): Promise<RunnerConnectionPayload> {
-  return await invoke<RunnerConnectionPayload>("ensure_runner_connection");
+export async function listDesktopRunnerSessions(repoUrl: string): Promise<RunnerSessionsPayload> {
+  return await invoke<RunnerSessionsPayload>("list_runner_sessions", { repoUrl });
 }
 
-export async function listDesktopRunnerSessions(): Promise<RunnerSessionsPayload> {
-  const connection = await ensureDesktopRunnerConnection();
-  const client = createLocalRunnerClient(connection);
-  const response = await client.listAssistantSessions();
-
-  return {
-    sessions: response.sessions,
-    workspaceDirectory: connection.workspaceDirectory,
-  };
-}
-
-export async function createDesktopRunnerSession(title: string): Promise<{ sessionId: string }> {
-  const connection = await ensureDesktopRunnerConnection();
-  const client = createLocalRunnerClient(connection);
-  const response = await client.ensureAssistantSession({
-    model: DEFAULT_OPENCODE_MODEL,
-    provider: DEFAULT_OPENCODE_PROVIDER,
-    taskTitle: title,
+export async function createDesktopRunnerSession(
+  title: string,
+  repoUrl: string,
+): Promise<{ sessionId: string }> {
+  return await invoke<{ sessionId: string }>("create_runner_session", {
+    repoUrl,
+    title,
   });
-
-  return { sessionId: response.sessionId };
 }

--- a/src/lib/runner-sessions.tsx
+++ b/src/lib/runner-sessions.tsx
@@ -7,6 +7,8 @@ import {
   useState,
 } from "react";
 import type { ReactNode } from "react";
+import { useLiveQuery } from "@tanstack/react-db";
+import { projectsCollection } from "@/lib/collections";
 import { createDesktopRunnerSession, listDesktopRunnerSessions } from "@/lib/desktop-runner";
 import type { RunnerSessionSummary } from "@/shared/runner-session";
 
@@ -29,13 +31,25 @@ export function RunnerSessionsProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(true);
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { data: projects, isLoading: isProjectLoading } = useLiveQuery((q) =>
+    q.from({ project: projectsCollection }).orderBy(({ project }) => project.created_at, "asc"),
+  );
   const isDesktopApp = detectDesktopApp();
+  const repoUrl = projects.find((project) => project.repo_url)?.repo_url ?? null;
   const loadSessions = useEffectEvent(async () => {
+    if (!repoUrl) {
+      setSessions([]);
+      setWorkspaceDirectory(null);
+      setError("Add a project with a repository URL to use runner sessions.");
+      setIsLoading(false);
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
 
     try {
-      const response = await listDesktopRunnerSessions();
+      const response = await listDesktopRunnerSessions(repoUrl);
       startTransition(() => {
         setSessions(response.sessions);
         setWorkspaceDirectory(response.workspaceDirectory);
@@ -56,8 +70,13 @@ export function RunnerSessionsProvider({ children }: { children: ReactNode }) {
       return;
     }
 
+    if (isProjectLoading) {
+      setIsLoading(true);
+      return;
+    }
+
     void loadSessions();
-  }, [isDesktopApp]);
+  }, [isDesktopApp, isProjectLoading, repoUrl]);
 
   async function refreshSessions(): Promise<void> {
     if (!isDesktopApp) {
@@ -68,11 +87,17 @@ export function RunnerSessionsProvider({ children }: { children: ReactNode }) {
   }
 
   async function createSession(title: string): Promise<{ sessionId: string }> {
+    if (!repoUrl) {
+      const message = "Add a project with a repository URL before creating a runner session.";
+      setError(message);
+      throw new Error(message);
+    }
+
     setIsCreating(true);
     setError(null);
 
     try {
-      const response = await createDesktopRunnerSession(title);
+      const response = await createDesktopRunnerSession(title, repoUrl);
       await refreshSessions();
       return response;
     } catch (createError) {


### PR DESCRIPTION
## Summary
- pass the first project repo URL through the desktop runner client and session provider
- create and refresh managed checkouts under `~/clanki/<repo>/default`, then open new runner sessions in per-session git worktrees
- aggregate runner sessions across managed worktree directories and clean up failed worktree setup paths

## Testing
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `bun run build`
- `bun run format`
- `bun run lint:fix`
- `bun run knip`