### PR TITLE
Move workspace lifecycle into runner

### DIFF
--- a/packages/desktop-shell/src/desktop-runner.mts
+++ b/packages/desktop-shell/src/desktop-runner.mts
@@ -1,12 +1,10 @@
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import {
   attachProcessStderr,
   reserveLocalPort,
   resolveBunBinary,
-  runCommand,
   stopChildProcess,
   waitForPort,
 } from "./node-utils.mjs";
@@ -28,20 +26,13 @@ type PromptRunnerTaskArgs = {
   sessionId: string;
 };
 
+type DeleteRunnerWorkspaceArgs = {
+  workspaceDirectory: string;
+};
+
 type RunnerProcess = {
   baseUrl: string;
   child: ChildProcess;
-};
-
-type PreparedWorktree = {
-  branchName: string;
-  defaultDirectory: string;
-  directory: string;
-};
-
-type RepoWorkspacePaths = {
-  defaultDirectory: string;
-  repoRoot: string;
 };
 
 type AppRunnerController = {
@@ -50,15 +41,21 @@ type AppRunnerController = {
     sessionId: string;
     workspaceDirectory: string;
   }>;
+  deleteRunnerWorkspace: (args: DeleteRunnerWorkspaceArgs) => Promise<void>;
   promptRunnerTask: (args: PromptRunnerTaskArgs) => Promise<void>;
   stop: () => Promise<void>;
 };
 
-type EnsureAssistantSessionResponse = {
+type CreateAssistantSessionResponse = {
   sessionId: string;
+  workspaceDirectory: string;
 };
 
 type PromptTaskAssistantSessionResponse = {
+  ok: boolean;
+};
+
+type DeleteWorkspaceResponse = {
   ok: boolean;
 };
 
@@ -80,28 +77,21 @@ export function createDesktopRunnerController({
     }
 
     const runner = await ensureRunner();
-    const worktree = prepareSessionWorktree(repoUrl, trimmedTitle);
+    const payload = await postRunnerJson<CreateAssistantSessionResponse>(
+      `${runner.baseUrl}/assistant/session/create`,
+      {
+        model: DEFAULT_OPENCODE_MODEL,
+        provider: DEFAULT_OPENCODE_PROVIDER,
+        repoUrl,
+        taskTitle: trimmedTitle,
+      },
+    );
 
-    try {
-      const payload = await postRunnerJson<EnsureAssistantSessionResponse>(
-        `${runner.baseUrl}/assistant/session/ensure`,
-        {
-          directory: worktree.directory,
-          model: DEFAULT_OPENCODE_MODEL,
-          provider: DEFAULT_OPENCODE_PROVIDER,
-          taskTitle: trimmedTitle,
-        },
-      );
-
-      return {
-        runnerType: "local-worktree",
-        sessionId: payload.sessionId,
-        workspaceDirectory: worktree.directory,
-      };
-    } catch (error) {
-      cleanupFailedWorktree(worktree);
-      throw error;
-    }
+    return {
+      runnerType: "local-worktree",
+      sessionId: payload.sessionId,
+      workspaceDirectory: payload.workspaceDirectory,
+    };
   }
 
   async function promptRunnerTask(args: PromptRunnerTaskArgs): Promise<void> {
@@ -123,6 +113,16 @@ export function createDesktopRunnerController({
     if (!payload.ok) {
       throw new Error("Local runner task prompt did not complete successfully");
     }
+  }
+
+  async function deleteRunnerWorkspace({
+    workspaceDirectory,
+  }: DeleteRunnerWorkspaceArgs): Promise<void> {
+    const runner = await ensureRunner();
+
+    await postRunnerJson<DeleteWorkspaceResponse>(`${runner.baseUrl}/workspace/delete`, {
+      workspaceDirectory,
+    });
   }
 
   async function stop(): Promise<void> {
@@ -190,200 +190,10 @@ export function createDesktopRunnerController({
 
   return {
     createRunnerSession,
+    deleteRunnerWorkspace,
     promptRunnerTask,
     stop,
   };
-}
-
-function prepareSessionWorktree(repoUrl: string, title: string): PreparedWorktree {
-  const workspace = resolveRepoWorkspacePaths(repoUrl);
-  const defaultBranch = ensureDefaultCheckout(repoUrl, workspace);
-  const identifier = nextWorktreeIdentifier(workspace.repoRoot, title);
-  const directory = path.join(workspace.repoRoot, identifier);
-  const branchName = `runner/${identifier}`;
-
-  runCommand(
-    "git",
-    [
-      "-C",
-      workspace.defaultDirectory,
-      "worktree",
-      "add",
-      "-b",
-      branchName,
-      directory,
-      defaultBranch,
-    ],
-    `Failed to create a worktree at ${directory}`,
-  );
-
-  return {
-    branchName,
-    defaultDirectory: workspace.defaultDirectory,
-    directory,
-  };
-}
-
-function cleanupFailedWorktree(worktree: PreparedWorktree): void {
-  try {
-    runCommand(
-      "git",
-      ["-C", worktree.defaultDirectory, "worktree", "remove", "--force", worktree.directory],
-      undefined,
-    );
-  } catch {}
-
-  try {
-    runCommand("git", ["-C", worktree.defaultDirectory, "branch", "-D", worktree.branchName]);
-  } catch {}
-}
-
-function ensureDefaultCheckout(repoUrl: string, workspace: RepoWorkspacePaths): string {
-  fs.mkdirSync(workspace.repoRoot, { recursive: true });
-
-  if (!fs.existsSync(workspace.defaultDirectory)) {
-    cloneDefaultCheckout(repoUrl, workspace.defaultDirectory);
-  } else if (!fs.existsSync(path.join(workspace.defaultDirectory, ".git"))) {
-    throw new Error(`Managed checkout exists without git metadata: ${workspace.defaultDirectory}`);
-  }
-
-  runCommand(
-    "git",
-    ["-C", workspace.defaultDirectory, "fetch", "origin", "--prune"],
-    `Failed to fetch the default checkout in ${workspace.defaultDirectory}`,
-  );
-
-  const defaultBranch = resolveDefaultBranch(workspace.defaultDirectory);
-
-  runCommand(
-    "git",
-    ["-C", workspace.defaultDirectory, "checkout", defaultBranch],
-    `Failed to checkout ${defaultBranch} in ${workspace.defaultDirectory}`,
-  );
-
-  runCommand(
-    "git",
-    ["-C", workspace.defaultDirectory, "pull", "--ff-only", "origin", defaultBranch],
-    `Failed to fast-forward ${defaultBranch} in ${workspace.defaultDirectory}`,
-  );
-
-  return defaultBranch;
-}
-
-function cloneDefaultCheckout(repoUrl: string, defaultDirectory: string): void {
-  fs.mkdirSync(path.dirname(defaultDirectory), { recursive: true });
-
-  const repoSlug = parseRepoSlug(repoUrl);
-  runCommand(
-    "gh",
-    ["repo", "clone", repoSlug, defaultDirectory],
-    `Failed to clone ${repoSlug} into ${defaultDirectory}`,
-  );
-}
-
-function resolveDefaultBranch(defaultDirectory: string): string {
-  const reference = runCommand(
-    "git",
-    ["-C", defaultDirectory, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-    `Failed to resolve the default branch for ${defaultDirectory}`,
-  )
-    .trim()
-    .replace(/^origin\//u, "");
-
-  if (!reference) {
-    throw new Error(`Failed to resolve the default branch for ${defaultDirectory}`);
-  }
-
-  return reference;
-}
-
-function nextWorktreeIdentifier(repoRoot: string, title: string): string {
-  const titleSlug = slugifyIdentifier(title);
-  const timestamp = Math.floor(Date.now() / 1_000);
-
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    const identifier =
-      attempt === 0 ? `${timestamp}-${titleSlug}` : `${timestamp}-${titleSlug}-${attempt}`;
-
-    if (!fs.existsSync(path.join(repoRoot, identifier))) {
-      return identifier;
-    }
-  }
-
-  throw new Error(`Failed to allocate a unique worktree directory in ${repoRoot}`);
-}
-
-function slugifyIdentifier(value: string): string {
-  let slug = "";
-  let lastWasSeparator = false;
-
-  for (const character of value) {
-    if (/[a-z0-9]/iu.test(character)) {
-      slug += character.toLowerCase();
-      lastWasSeparator = false;
-      continue;
-    }
-
-    if (!lastWasSeparator) {
-      slug += "-";
-      lastWasSeparator = true;
-    }
-  }
-
-  const trimmed = slug.replace(/^-+|-+$/gu, "");
-  return trimmed || "session";
-}
-
-function resolveRepoWorkspacePaths(repoUrl: string): RepoWorkspacePaths {
-  const repoName = parseRepoName(repoUrl);
-  const repoRoot = path.join(resolveRunnerRoot(), repoName);
-
-  return {
-    defaultDirectory: path.join(repoRoot, "default"),
-    repoRoot,
-  };
-}
-
-function resolveRunnerRoot(): string {
-  return path.join(os.homedir(), "clanki");
-}
-
-function parseRepoSlug(repoUrl: string): string {
-  const normalized = normalizeRepoReference(repoUrl);
-  let repoPath = normalized;
-
-  if (repoPath.startsWith("https://github.com/")) {
-    repoPath = repoPath.slice("https://github.com/".length);
-  } else if (repoPath.startsWith("git@github.com:")) {
-    repoPath = repoPath.slice("git@github.com:".length);
-  } else if (repoPath.startsWith("ssh://git@github.com/")) {
-    repoPath = repoPath.slice("ssh://git@github.com/".length);
-  }
-
-  const segments = repoPath.split("/").filter(Boolean);
-  if (segments.length !== 2) {
-    throw new Error(`Unsupported GitHub repository URL: ${repoUrl}`);
-  }
-
-  return `${segments[0]}/${segments[1]}`;
-}
-
-function parseRepoName(repoUrl: string): string {
-  const repoSlug = parseRepoSlug(repoUrl);
-  const repoName = repoSlug.split("/")[1];
-
-  if (!repoName) {
-    throw new Error(`Unsupported GitHub repository URL: ${repoUrl}`);
-  }
-
-  return repoName;
-}
-
-function normalizeRepoReference(repoUrl: string): string {
-  return repoUrl
-    .trim()
-    .replace(/\/+$/u, "")
-    .replace(/\.git$/u, "");
 }
 
 async function isRunnerHealthy(baseUrl: string): Promise<boolean> {

--- a/packages/desktop-shell/src/index.mts
+++ b/packages/desktop-shell/src/index.mts
@@ -16,6 +16,10 @@ function registerIpcHandlers(): void {
     return await desktopRunnerController.createRunnerSession(args);
   });
 
+  ipcMain.handle("desktop-runner:delete-workspace", async (_event, args) => {
+    return await desktopRunnerController.deleteRunnerWorkspace(args);
+  });
+
   ipcMain.handle("desktop-runner:prompt-task", async (_event, args) => {
     return await desktopRunnerController.promptRunnerTask(args);
   });

--- a/packages/desktop-shell/src/node-utils.mts
+++ b/packages/desktop-shell/src/node-utils.mts
@@ -1,4 +1,4 @@
-import { spawnSync, type ChildProcess } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import net from "node:net";
 import { setTimeout as delay } from "node:timers/promises";
 
@@ -80,34 +80,6 @@ export async function waitForPort(port: number, options: WaitOptions = {}): Prom
 export function resolveBunBinary(): string {
   const configuredPath = process.env.BUN_BINARY?.trim();
   return configuredPath || "bun";
-}
-
-export function runCommand(program: string, args: string[], errorContext?: string): string {
-  const output = spawnSync(program, args, {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-  if (output.error) {
-    const message = errorContext
-      ? `${errorContext}: ${output.error.message}`
-      : `Failed to run ${program}: ${output.error.message}`;
-    throw new Error(message);
-  }
-
-  if (output.status === 0) {
-    return output.stdout;
-  }
-
-  const stderr = output.stderr.trim();
-  const stdout = output.stdout.trim();
-  const details = stderr || stdout || `exit status ${output.status}`;
-
-  if (errorContext) {
-    throw new Error(`${errorContext}: ${details}`);
-  }
-
-  throw new Error(`Command ${program} failed: ${details}`);
 }
 
 export async function stopChildProcess(child: ChildProcess | null | undefined): Promise<void> {

--- a/packages/desktop-shell/src/preload.mts
+++ b/packages/desktop-shell/src/preload.mts
@@ -4,6 +4,9 @@ contextBridge.exposeInMainWorld("clankiDesktop", {
   createRunnerSession(title: string, repoUrl: string) {
     return ipcRenderer.invoke("desktop-runner:create-session", { repoUrl, title });
   },
+  deleteRunnerWorkspace(workspaceDirectory: string) {
+    return ipcRenderer.invoke("desktop-runner:delete-workspace", { workspaceDirectory });
+  },
   promptRunnerTask(args: {
     backendBaseUrl: string;
     callbackToken: string;

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -7,3 +7,4 @@ export * from "./task-assistant-session";
 export * from "./opencode";
 export * from "./opencode-models";
 export * from "./opencode";
+export * from "./workspace";

--- a/packages/runner/src/local-runner-client.ts
+++ b/packages/runner/src/local-runner-client.ts
@@ -1,4 +1,8 @@
 import type {
+  CreateAssistantSessionRequest,
+  CreateAssistantSessionResponse,
+  DeleteWorkspaceRequest,
+  DeleteWorkspaceResponse,
   EnsureAssistantSessionRequest,
   EnsureAssistantSessionResponse,
   ListAssistantSessionsRequest,
@@ -15,6 +19,14 @@ export function createLocalRunnerClient(baseUrl: string) {
   const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
 
   return {
+    async createAssistantSession(
+      body: CreateAssistantSessionRequest,
+    ): Promise<CreateAssistantSessionResponse> {
+      return await postJson(`${normalizedBaseUrl}/assistant/session/create`, body);
+    },
+    async deleteWorkspace(body: DeleteWorkspaceRequest): Promise<DeleteWorkspaceResponse> {
+      return await postJson(`${normalizedBaseUrl}/workspace/delete`, body);
+    },
     async ensureAssistantSession(
       body: EnsureAssistantSessionRequest,
     ): Promise<EnsureAssistantSessionResponse> {

--- a/packages/runner/src/local-runner-protocol.ts
+++ b/packages/runner/src/local-runner-protocol.ts
@@ -26,6 +26,18 @@ export type ListOpencodeModelsResponse = {
   providers: Array<LocalRunnerOpencodeProvider>;
 };
 
+export type CreateAssistantSessionRequest = {
+  model: string;
+  provider: string;
+  repoUrl: string;
+  taskTitle: string;
+};
+
+export type CreateAssistantSessionResponse = {
+  sessionId: string;
+  workspaceDirectory: string;
+};
+
 export type EnsureAssistantSessionRequest = {
   directory: string;
   model: string;
@@ -77,5 +89,13 @@ export type PromptTaskAssistantSessionRequest = {
 };
 
 export type PromptTaskAssistantSessionResponse = {
+  ok: true;
+};
+
+export type DeleteWorkspaceRequest = {
+  workspaceDirectory: string;
+};
+
+export type DeleteWorkspaceResponse = {
   ok: true;
 };

--- a/packages/runner/src/local-runner-server.ts
+++ b/packages/runner/src/local-runner-server.ts
@@ -5,6 +5,8 @@ import { ensureAssistantSession, promptAssistantSession } from "./assistant-sess
 import { listAssistantSessions } from "./list-assistant-sessions";
 import {
   LOCAL_RUNNER_PROTOCOL_VERSION,
+  type CreateAssistantSessionRequest,
+  type DeleteWorkspaceRequest,
   type EnsureAssistantSessionRequest,
   type ListAssistantSessionsRequest,
   type ListOpencodeModelsRequest,
@@ -13,6 +15,7 @@ import {
 } from "./local-runner-protocol";
 import { listOpencodeModels } from "./opencode-models";
 import { promptTaskAssistantSession } from "./task-assistant-session";
+import { createWorkspace, deleteWorkspace } from "./workspace";
 
 export type LocalRunnerServerOptions = {
   host?: string;
@@ -73,6 +76,32 @@ export function createLocalRunnerApp(): Hono {
     });
   });
 
+  app.post("/assistant/session/create", async (c) => {
+    const body = await readJson<CreateAssistantSessionRequest>(c);
+    const workspaceDirectory = createWorkspace({
+      repoUrl: body.repoUrl,
+      title: body.taskTitle,
+    });
+
+    try {
+      const session = await ensureAssistantSession({
+        directory: workspaceDirectory,
+        existingSessionId: null,
+        model: body.model,
+        provider: body.provider,
+        taskTitle: body.taskTitle,
+      });
+
+      return c.json({
+        sessionId: session.sessionId,
+        workspaceDirectory,
+      });
+    } catch (error) {
+      deleteWorkspace(workspaceDirectory);
+      throw error;
+    }
+  });
+
   app.post("/assistant/session/ensure", async (c) => {
     const body = await readJson<EnsureAssistantSessionRequest>(c);
 
@@ -85,6 +114,14 @@ export function createLocalRunnerApp(): Hono {
         taskTitle: body.taskTitle,
       }),
     );
+  });
+
+  app.post("/workspace/delete", async (c) => {
+    const body = await readJson<DeleteWorkspaceRequest>(c);
+
+    deleteWorkspace(body.workspaceDirectory);
+
+    return c.json({ ok: true });
   });
 
   app.post("/assistant/session/prompt", async (c) => {

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -1,0 +1,298 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+type CreateWorkspaceArgs = {
+  repoUrl: string;
+  title: string;
+};
+
+type PreparedWorkspace = {
+  branchName: string;
+  defaultDirectory: string;
+  directory: string;
+};
+
+type RepoWorkspacePaths = {
+  defaultDirectory: string;
+  repoRoot: string;
+};
+
+export function createWorkspace({ repoUrl, title }: CreateWorkspaceArgs): string {
+  const trimmedTitle = title.trim();
+  if (trimmedTitle.length === 0) {
+    throw new Error("title is required");
+  }
+
+  return prepareSessionWorktree(repoUrl, trimmedTitle).directory;
+}
+
+export function deleteWorkspace(workspaceDirectory: string): void {
+  const managedWorkspaceDirectory = resolveManagedWorkspaceDirectory(workspaceDirectory);
+  const defaultDirectory = resolveRepoDefaultDirectory(managedWorkspaceDirectory);
+
+  if (!fs.existsSync(managedWorkspaceDirectory)) {
+    removeManagedWorktreeBranch(managedWorkspaceDirectory);
+    return;
+  }
+
+  if (!fs.existsSync(defaultDirectory)) {
+    fs.rmSync(managedWorkspaceDirectory, { force: true, recursive: true });
+    return;
+  }
+
+  runCommand(
+    "git",
+    ["-C", defaultDirectory, "worktree", "remove", "--force", managedWorkspaceDirectory],
+    `Failed to remove the worktree at ${managedWorkspaceDirectory}`,
+  );
+
+  removeManagedWorktreeBranch(managedWorkspaceDirectory);
+}
+
+function prepareSessionWorktree(repoUrl: string, title: string): PreparedWorkspace {
+  const workspace = resolveRepoWorkspacePaths(repoUrl);
+  const defaultBranch = ensureDefaultCheckout(repoUrl, workspace);
+  const identifier = nextWorktreeIdentifier(workspace.repoRoot, title);
+  const directory = path.join(workspace.repoRoot, identifier);
+  const branchName = `runner/${identifier}`;
+
+  runCommand(
+    "git",
+    [
+      "-C",
+      workspace.defaultDirectory,
+      "worktree",
+      "add",
+      "-b",
+      branchName,
+      directory,
+      defaultBranch,
+    ],
+    `Failed to create a worktree at ${directory}`,
+  );
+
+  return {
+    branchName,
+    defaultDirectory: workspace.defaultDirectory,
+    directory,
+  };
+}
+
+function removeManagedWorktreeBranch(workspaceDirectory: string): void {
+  const defaultDirectory = resolveRepoDefaultDirectory(workspaceDirectory);
+
+  if (!fs.existsSync(defaultDirectory)) {
+    return;
+  }
+
+  try {
+    runCommand(
+      "git",
+      ["-C", defaultDirectory, "branch", "-D", resolveManagedBranchName(workspaceDirectory)],
+      undefined,
+    );
+  } catch {}
+}
+
+function ensureDefaultCheckout(repoUrl: string, workspace: RepoWorkspacePaths): string {
+  fs.mkdirSync(workspace.repoRoot, { recursive: true });
+
+  if (!fs.existsSync(workspace.defaultDirectory)) {
+    cloneDefaultCheckout(repoUrl, workspace.defaultDirectory);
+  } else if (!fs.existsSync(path.join(workspace.defaultDirectory, ".git"))) {
+    throw new Error(`Managed checkout exists without git metadata: ${workspace.defaultDirectory}`);
+  }
+
+  runCommand(
+    "git",
+    ["-C", workspace.defaultDirectory, "fetch", "origin", "--prune"],
+    `Failed to fetch the default checkout in ${workspace.defaultDirectory}`,
+  );
+
+  const defaultBranch = resolveDefaultBranch(workspace.defaultDirectory);
+
+  runCommand(
+    "git",
+    ["-C", workspace.defaultDirectory, "checkout", defaultBranch],
+    `Failed to checkout ${defaultBranch} in ${workspace.defaultDirectory}`,
+  );
+
+  runCommand(
+    "git",
+    ["-C", workspace.defaultDirectory, "pull", "--ff-only", "origin", defaultBranch],
+    `Failed to fast-forward ${defaultBranch} in ${workspace.defaultDirectory}`,
+  );
+
+  return defaultBranch;
+}
+
+function cloneDefaultCheckout(repoUrl: string, defaultDirectory: string): void {
+  fs.mkdirSync(path.dirname(defaultDirectory), { recursive: true });
+
+  const repoSlug = parseRepoSlug(repoUrl);
+  runCommand(
+    "gh",
+    ["repo", "clone", repoSlug, defaultDirectory],
+    `Failed to clone ${repoSlug} into ${defaultDirectory}`,
+  );
+}
+
+function resolveDefaultBranch(defaultDirectory: string): string {
+  const reference = runCommand(
+    "git",
+    ["-C", defaultDirectory, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+    `Failed to resolve the default branch for ${defaultDirectory}`,
+  )
+    .trim()
+    .replace(/^origin\//u, "");
+
+  if (!reference) {
+    throw new Error(`Failed to resolve the default branch for ${defaultDirectory}`);
+  }
+
+  return reference;
+}
+
+function nextWorktreeIdentifier(repoRoot: string, title: string): string {
+  const titleSlug = slugifyIdentifier(title);
+  const timestamp = Math.floor(Date.now() / 1_000);
+
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const identifier =
+      attempt === 0 ? `${timestamp}-${titleSlug}` : `${timestamp}-${titleSlug}-${attempt}`;
+
+    if (!fs.existsSync(path.join(repoRoot, identifier))) {
+      return identifier;
+    }
+  }
+
+  throw new Error(`Failed to allocate a unique worktree directory in ${repoRoot}`);
+}
+
+function slugifyIdentifier(value: string): string {
+  let slug = "";
+  let lastWasSeparator = false;
+
+  for (const character of value) {
+    if (/[a-z0-9]/iu.test(character)) {
+      slug += character.toLowerCase();
+      lastWasSeparator = false;
+      continue;
+    }
+
+    if (!lastWasSeparator) {
+      slug += "-";
+      lastWasSeparator = true;
+    }
+  }
+
+  const trimmed = slug.replace(/^-+|-+$/gu, "");
+  return trimmed || "session";
+}
+
+function resolveRepoWorkspacePaths(repoUrl: string): RepoWorkspacePaths {
+  const repoName = parseRepoName(repoUrl);
+  const repoRoot = path.join(resolveRunnerRoot(), repoName);
+
+  return {
+    defaultDirectory: path.join(repoRoot, "default"),
+    repoRoot,
+  };
+}
+
+function resolveRunnerRoot(): string {
+  return path.join(os.homedir(), "clanki");
+}
+
+function resolveManagedWorkspaceDirectory(workspaceDirectory: string): string {
+  const resolvedWorkspaceDirectory = path.resolve(workspaceDirectory);
+  const runnerRoot = resolveRunnerRoot();
+  const relativePath = path.relative(runnerRoot, resolvedWorkspaceDirectory);
+
+  if (
+    relativePath.startsWith("..") ||
+    path.isAbsolute(relativePath) ||
+    relativePath.length === 0 ||
+    path.basename(resolvedWorkspaceDirectory) === "default"
+  ) {
+    throw new Error(`Refusing to remove unmanaged workspace: ${workspaceDirectory}`);
+  }
+
+  return resolvedWorkspaceDirectory;
+}
+
+function resolveRepoDefaultDirectory(workspaceDirectory: string): string {
+  return path.join(path.dirname(workspaceDirectory), "default");
+}
+
+function resolveManagedBranchName(workspaceDirectory: string): string {
+  return `runner/${path.basename(workspaceDirectory)}`;
+}
+
+function parseRepoSlug(repoUrl: string): string {
+  const normalized = normalizeRepoReference(repoUrl);
+  let repoPath = normalized;
+
+  if (repoPath.startsWith("https://github.com/")) {
+    repoPath = repoPath.slice("https://github.com/".length);
+  } else if (repoPath.startsWith("git@github.com:")) {
+    repoPath = repoPath.slice("git@github.com:".length);
+  } else if (repoPath.startsWith("ssh://git@github.com/")) {
+    repoPath = repoPath.slice("ssh://git@github.com/".length);
+  }
+
+  const segments = repoPath.split("/").filter(Boolean);
+  if (segments.length !== 2) {
+    throw new Error(`Unsupported GitHub repository URL: ${repoUrl}`);
+  }
+
+  return `${segments[0]}/${segments[1]}`;
+}
+
+function parseRepoName(repoUrl: string): string {
+  const repoSlug = parseRepoSlug(repoUrl);
+  const repoName = repoSlug.split("/")[1];
+
+  if (!repoName) {
+    throw new Error(`Unsupported GitHub repository URL: ${repoUrl}`);
+  }
+
+  return repoName;
+}
+
+function normalizeRepoReference(repoUrl: string): string {
+  return repoUrl
+    .trim()
+    .replace(/\/+$/u, "")
+    .replace(/\.git$/u, "");
+}
+
+function runCommand(program: string, args: string[], errorContext?: string): string {
+  const output = spawnSync(program, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (output.error) {
+    const message = errorContext
+      ? `${errorContext}: ${output.error.message}`
+      : `Failed to run ${program}: ${output.error.message}`;
+    throw new Error(message);
+  }
+
+  if (output.status === 0) {
+    return output.stdout;
+  }
+
+  const stderr = output.stderr.trim();
+  const stdout = output.stdout.trim();
+  const details = stderr || stdout || `exit status ${output.status}`;
+
+  if (errorContext) {
+    throw new Error(`${errorContext}: ${details}`);
+  }
+
+  throw new Error(`Command ${program} failed: ${details}`);
+}

--- a/src/components/layout/task-list.tsx
+++ b/src/components/layout/task-list.tsx
@@ -26,7 +26,7 @@ import {
   getPullRequestStatus,
   type PullRequestStatus,
 } from "../../lib/pull-request";
-import { createDesktopRunnerSession } from "@/lib/desktop-runner";
+import { createDesktopRunnerSession, deleteDesktopRunnerWorkspace } from "@/lib/desktop-runner";
 
 type TaskSidebarGroup = "merged" | "needsAction" | "openNoPr" | "awaitingReview" | "running";
 
@@ -217,11 +217,17 @@ export function TaskList() {
     }
 
     const deletingTaskId = targetTask.id;
+    const taskRecord = tasks.find((candidateTask) => candidateTask.id === deletingTaskId);
+    const workspacePath = taskRecord?.workspace_path?.trim();
 
     setDeletingTask(true);
     setDeleteError(null);
 
     try {
+      if (taskRecord?.runner_type === "local-worktree" && workspacePath) {
+        await deleteDesktopRunnerWorkspace(workspacePath);
+      }
+
       tasksCollection.delete(deletingTaskId);
       setTaskToDelete((currentTask) => (currentTask?.id === deletingTaskId ? null : currentTask));
     } catch (error) {

--- a/src/lib/desktop-runner.ts
+++ b/src/lib/desktop-runner.ts
@@ -9,6 +9,7 @@ type DesktopRunnerBridge = {
     title: string,
     repoUrl: string,
   ) => Promise<CreateDesktopRunnerSessionResponse>;
+  deleteRunnerWorkspace: (workspaceDirectory: string) => Promise<void>;
   promptRunnerTask: (args: {
     backendBaseUrl: string;
     callbackToken: string;
@@ -38,6 +39,10 @@ export async function createDesktopRunnerSession(
   repoUrl: string,
 ): Promise<{ runnerType: string; sessionId: string; workspaceDirectory: string }> {
   return await getDesktopRunnerBridge().createRunnerSession(title, repoUrl);
+}
+
+export async function deleteDesktopRunnerWorkspace(workspaceDirectory: string): Promise<void> {
+  await getDesktopRunnerBridge().deleteRunnerWorkspace(workspaceDirectory);
 }
 
 export async function promptDesktopRunnerTask(args: {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -17,7 +17,6 @@ import { Route as LayoutSettingsRouteImport } from './routes/_layout.settings'
 import { Route as LayoutRunnerIndexRouteImport } from './routes/_layout.runner.index'
 import { Route as ApiTasksShapeRouteImport } from './routes/api/tasks/shape'
 import { Route as ApiPullRequestsShapeRouteImport } from './routes/api/pull-requests/shape'
-import { Route as ApiProviderCredentialsShapeRouteImport } from './routes/api/provider-credentials/shape'
 import { Route as ApiProjectsShapeRouteImport } from './routes/api/projects/shape'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as LayoutTasksTaskIdRouteImport } from './routes/_layout.tasks.$taskId'
@@ -70,12 +69,6 @@ const ApiPullRequestsShapeRoute = ApiPullRequestsShapeRouteImport.update({
   path: '/api/pull-requests/shape',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiProviderCredentialsShapeRoute =
-  ApiProviderCredentialsShapeRouteImport.update({
-    id: '/api/provider-credentials/shape',
-    path: '/api/provider-credentials/shape',
-    getParentRoute: () => rootRouteImport,
-  } as any)
 const ApiProjectsShapeRoute = ApiProjectsShapeRouteImport.update({
   id: '/api/projects/shape',
   path: '/api/projects/shape',
@@ -152,7 +145,6 @@ export interface FileRoutesByFullPath {
   '/tasks/$taskId': typeof LayoutTasksTaskIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/projects/shape': typeof ApiProjectsShapeRoute
-  '/api/provider-credentials/shape': typeof ApiProviderCredentialsShapeRoute
   '/api/pull-requests/shape': typeof ApiPullRequestsShapeRoute
   '/api/tasks/shape': typeof ApiTasksShapeRoute
   '/runner/': typeof LayoutRunnerIndexRoute
@@ -174,7 +166,6 @@ export interface FileRoutesByTo {
   '/tasks/$taskId': typeof LayoutTasksTaskIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/projects/shape': typeof ApiProjectsShapeRoute
-  '/api/provider-credentials/shape': typeof ApiProviderCredentialsShapeRoute
   '/api/pull-requests/shape': typeof ApiPullRequestsShapeRoute
   '/api/tasks/shape': typeof ApiTasksShapeRoute
   '/runner': typeof LayoutRunnerIndexRoute
@@ -198,7 +189,6 @@ export interface FileRoutesById {
   '/_layout/tasks/$taskId': typeof LayoutTasksTaskIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/projects/shape': typeof ApiProjectsShapeRoute
-  '/api/provider-credentials/shape': typeof ApiProviderCredentialsShapeRoute
   '/api/pull-requests/shape': typeof ApiPullRequestsShapeRoute
   '/api/tasks/shape': typeof ApiTasksShapeRoute
   '/_layout/runner/': typeof LayoutRunnerIndexRoute
@@ -222,7 +212,6 @@ export interface FileRouteTypes {
     | '/tasks/$taskId'
     | '/api/auth/$'
     | '/api/projects/shape'
-    | '/api/provider-credentials/shape'
     | '/api/pull-requests/shape'
     | '/api/tasks/shape'
     | '/runner/'
@@ -244,7 +233,6 @@ export interface FileRouteTypes {
     | '/tasks/$taskId'
     | '/api/auth/$'
     | '/api/projects/shape'
-    | '/api/provider-credentials/shape'
     | '/api/pull-requests/shape'
     | '/api/tasks/shape'
     | '/runner'
@@ -267,7 +255,6 @@ export interface FileRouteTypes {
     | '/_layout/tasks/$taskId'
     | '/api/auth/$'
     | '/api/projects/shape'
-    | '/api/provider-credentials/shape'
     | '/api/pull-requests/shape'
     | '/api/tasks/shape'
     | '/_layout/runner/'
@@ -287,7 +274,6 @@ export interface RootRouteChildren {
   WebhookRoute: typeof WebhookRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiProjectsShapeRoute: typeof ApiProjectsShapeRoute
-  ApiProviderCredentialsShapeRoute: typeof ApiProviderCredentialsShapeRoute
   ApiPullRequestsShapeRoute: typeof ApiPullRequestsShapeRoute
   ApiTasksShapeRoute: typeof ApiTasksShapeRoute
   ApiTasksTaskIdStreamRoute: typeof ApiTasksTaskIdStreamRoute
@@ -356,13 +342,6 @@ declare module '@tanstack/react-router' {
       path: '/api/pull-requests/shape'
       fullPath: '/api/pull-requests/shape'
       preLoaderRoute: typeof ApiPullRequestsShapeRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/provider-credentials/shape': {
-      id: '/api/provider-credentials/shape'
-      path: '/api/provider-credentials/shape'
-      fullPath: '/api/provider-credentials/shape'
-      preLoaderRoute: typeof ApiProviderCredentialsShapeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/projects/shape': {
@@ -477,7 +456,6 @@ const rootRouteChildren: RootRouteChildren = {
   WebhookRoute: WebhookRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiProjectsShapeRoute: ApiProjectsShapeRoute,
-  ApiProviderCredentialsShapeRoute: ApiProviderCredentialsShapeRoute,
   ApiPullRequestsShapeRoute: ApiPullRequestsShapeRoute,
   ApiTasksShapeRoute: ApiTasksShapeRoute,
   ApiTasksTaskIdStreamRoute: ApiTasksTaskIdStreamRoute,


### PR DESCRIPTION
Move local workspace creation and deletion into the runner package and expose runner endpoints for session setup and workspace cleanup. Keep the Electron desktop shell as a thin host/proxy for those runner operations, and update task deletion to remove local runner workspaces through that path. This also regenerates the route tree to drop stale provider-credentials shape entries.