### PR TITLE
Add runner model selection to task composer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/electric-db-collection": "^0.2.33",
         "@tanstack/react-db": "0.1.70",
+        "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-router": "^1.162.8",
         "@tanstack/react-start": "^1.162.8",
         "better-auth": "^1.4.18",
@@ -705,7 +706,11 @@
 
     "@tanstack/pacer-lite": ["@tanstack/pacer-lite@0.2.1", "", {}, "sha512-3PouiFjR4B6x1c969/Pl4ZIJleof1M0n6fNX8NRiC9Sqv1g06CVDlEaXUR4212ycGFyfq4q+t8Gi37Xy+z34iQ=="],
 
+    "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
+
     "@tanstack/react-db": ["@tanstack/react-db@0.1.70", "", { "dependencies": { "@tanstack/db": "0.5.26", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-OISznZtrjkbyktbAoj/2KyFf9Xv9vr7JfkQO4od4eH76X+vQXYZkVgs2IV5sM27YNatOyf1Or4BEELIbyYB4xA=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
 
     "@tanstack/react-router": ["@tanstack/react-router@1.162.8", "", { "dependencies": { "@tanstack/history": "1.161.4", "@tanstack/react-store": "^0.9.1", "@tanstack/router-core": "1.162.6", "isbot": "^5.1.22", "tiny-invariant": "^1.3.3", "tiny-warning": "^1.0.3" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-WunoknGI5ielJ833yl/F7Vq4nv/OWzrJVBsMgyxX16Db1DwVvX/B5zTg8EMjdZUOJ7ONpvur3t4aq7KQiYRagQ=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/electric-db-collection": "^0.2.33",
     "@tanstack/react-db": "0.1.70",
+    "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-router": "^1.162.8",
     "@tanstack/react-start": "^1.162.8",
     "better-auth": "^1.4.18",

--- a/packages/desktop-shell/src/desktop-runner.mts
+++ b/packages/desktop-shell/src/desktop-runner.mts
@@ -17,12 +17,26 @@ type CreateRunnerSessionArgs = {
   title: string;
 };
 
+type RunnerModelProvider = {
+  id: string;
+  models: Record<string, { id: string; name: string }>;
+  name: string;
+};
+
+type ListRunnerModelsResponse = {
+  connected: string[];
+  default: Record<string, string>;
+  providers: RunnerModelProvider[];
+};
+
 type PromptRunnerTaskArgs = {
   backendBaseUrl: string;
   callbackToken: string;
   directory: string;
   executionId: string;
+  model?: string;
   prompt: string;
+  provider?: string;
   sessionId: string;
 };
 
@@ -42,6 +56,7 @@ type AppRunnerController = {
     workspaceDirectory: string;
   }>;
   deleteRunnerWorkspace: (args: DeleteRunnerWorkspaceArgs) => Promise<void>;
+  listRunnerModels: (args: { directory: string }) => Promise<ListRunnerModelsResponse>;
   promptRunnerTask: (args: PromptRunnerTaskArgs) => Promise<void>;
   stop: () => Promise<void>;
 };
@@ -94,13 +109,24 @@ export function createDesktopRunnerController({
     };
   }
 
+  async function listRunnerModels(args: { directory: string }): Promise<ListRunnerModelsResponse> {
+    const runner = await ensureRunner();
+    return await getRunnerJson<ListRunnerModelsResponse>(
+      `${runner.baseUrl}/opencode/models?${new URLSearchParams({
+        directory: args.directory,
+      }).toString()}`,
+    );
+  }
+
   async function promptRunnerTask(args: PromptRunnerTaskArgs): Promise<void> {
     const runner = await ensureRunner();
     const payload = await postRunnerJson<PromptTaskAssistantSessionResponse>(
       `${runner.baseUrl}/assistant/session/task-prompt`,
       {
         directory: args.directory,
+        model: args.model,
         prompt: args.prompt,
+        provider: args.provider,
         sessionId: args.sessionId,
         taskRun: {
           backendBaseUrl: args.backendBaseUrl,
@@ -191,6 +217,7 @@ export function createDesktopRunnerController({
   return {
     createRunnerSession,
     deleteRunnerWorkspace,
+    listRunnerModels,
     promptRunnerTask,
     stop,
   };
@@ -203,6 +230,11 @@ async function isRunnerHealthy(baseUrl: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function getRunnerJson<T>(url: string): Promise<T> {
+  const response = await fetch(url);
+  return await parseRunnerJson<T>(response);
 }
 
 async function postRunnerJson<T>(url: string, body: unknown): Promise<T> {

--- a/packages/desktop-shell/src/index.mts
+++ b/packages/desktop-shell/src/index.mts
@@ -20,6 +20,10 @@ function registerIpcHandlers(): void {
     return await desktopRunnerController.deleteRunnerWorkspace(args);
   });
 
+  ipcMain.handle("desktop-runner:list-models", async (_event, args) => {
+    return await desktopRunnerController.listRunnerModels(args);
+  });
+
   ipcMain.handle("desktop-runner:prompt-task", async (_event, args) => {
     return await desktopRunnerController.promptRunnerTask(args);
   });

--- a/packages/desktop-shell/src/preload.mts
+++ b/packages/desktop-shell/src/preload.mts
@@ -7,12 +7,17 @@ contextBridge.exposeInMainWorld("clankiDesktop", {
   deleteRunnerWorkspace(workspaceDirectory: string) {
     return ipcRenderer.invoke("desktop-runner:delete-workspace", { workspaceDirectory });
   },
+  listRunnerModels(args: { directory: string }) {
+    return ipcRenderer.invoke("desktop-runner:list-models", args);
+  },
   promptRunnerTask(args: {
     backendBaseUrl: string;
     callbackToken: string;
     directory: string;
     executionId: string;
+    model?: string;
     prompt: string;
+    provider?: string;
     sessionId: string;
   }) {
     return ipcRenderer.invoke("desktop-runner:prompt-task", args);

--- a/packages/runner/src/assistant-session.ts
+++ b/packages/runner/src/assistant-session.ts
@@ -4,16 +4,20 @@ import { toProviderModelRef } from "./opencode";
 export async function ensureAssistantSession(args: {
   directory: string;
   existingSessionId?: string | null;
-  model: string;
-  provider: string;
+  model?: string;
+  provider?: string;
   taskTitle: string;
 }): Promise<{ isNewSession: boolean; sessionId: string }> {
+  const clientConfig =
+    args.provider && args.model
+      ? {
+          enabled_providers: [args.provider],
+          model: toProviderModelRef(args.provider, args.model),
+        }
+      : undefined;
   const { client } = await createLocalRunnerOpencodeClient({
     directory: args.directory,
-    config: {
-      enabled_providers: [args.provider],
-      model: toProviderModelRef(args.provider, args.model),
-    },
+    config: clientConfig,
   });
 
   let sessionId = args.existingSessionId?.trim() ?? "";
@@ -52,6 +56,8 @@ export async function ensureAssistantSession(args: {
 
 export async function promptAssistantSession(args: {
   directory: string;
+  model?: string;
+  provider?: string;
   prompt: string;
   sessionId: string;
 }): Promise<void> {
@@ -62,6 +68,13 @@ export async function promptAssistantSession(args: {
     path: { id: args.sessionId },
     query: { directory: args.directory },
     body: {
+      model:
+        args.provider && args.model
+          ? {
+              modelID: args.model,
+              providerID: args.provider,
+            }
+          : undefined,
       parts: [{ type: "text", text: args.prompt }],
     },
   });

--- a/packages/runner/src/local-runner-protocol.ts
+++ b/packages/runner/src/local-runner-protocol.ts
@@ -40,8 +40,8 @@ export type CreateAssistantSessionResponse = {
 
 export type EnsureAssistantSessionRequest = {
   directory: string;
-  model: string;
-  provider: string;
+  model?: string;
+  provider?: string;
   sessionId?: string | null;
   taskTitle: string;
 };
@@ -69,6 +69,8 @@ export type ListAssistantSessionsResponse = {
 
 export type PromptAssistantSessionRequest = {
   directory: string;
+  model?: string;
+  provider?: string;
   prompt: string;
   sessionId: string;
 };
@@ -79,6 +81,8 @@ export type PromptAssistantSessionResponse = {
 
 export type PromptTaskAssistantSessionRequest = {
   directory: string;
+  model?: string;
+  provider?: string;
   prompt: string;
   sessionId: string;
   taskRun: {

--- a/packages/runner/src/task-assistant-session.ts
+++ b/packages/runner/src/task-assistant-session.ts
@@ -10,6 +10,8 @@ type TaskRunCallbackInfo = {
 
 export async function promptTaskAssistantSession(args: {
   directory: string;
+  model?: string;
+  provider?: string;
   prompt: string;
   sessionId: string;
   taskRun: TaskRunCallbackInfo;
@@ -35,7 +37,9 @@ export async function promptTaskAssistantSession(args: {
 
     await promptAssistantSession({
       directory: args.directory,
+      model: args.model,
       prompt: args.prompt,
+      provider: args.provider,
       sessionId: args.sessionId,
     });
 

--- a/src/components/app-query-provider.tsx
+++ b/src/components/app-query-provider.tsx
@@ -1,0 +1,8 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const appQueryClient = new QueryClient();
+
+export function AppQueryProvider({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={appQueryClient}>{children}</QueryClientProvider>;
+}

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
+import { AppQueryProvider } from "@/components/app-query-provider";
 import { RunnerSessionsProvider } from "@/lib/runner-sessions";
 import { cn } from "../lib/utils";
 import { useSession } from "../lib/auth-client";
@@ -35,37 +36,39 @@ export function Layout() {
   if (!session) return null;
 
   return (
-    <RunnerSessionsProvider>
-      <div className="neo-enter flex h-dvh bg-background text-foreground">
-        <div
-          className={cn(
-            "fixed inset-0 z-40 bg-[rgb(18_18_18_/_0.32)] backdrop-blur-[1px] transition-opacity md:hidden",
-            sidebarOpen ? "opacity-100" : "opacity-0 pointer-events-none",
-          )}
-          onClick={() => setSidebarOpen(false)}
-        />
-
-        <div
-          className={cn(
-            "fixed inset-y-0 left-0 z-50 w-full max-w-full overflow-hidden border-r border-border bg-card transition-transform duration-200 ease-in-out",
-            "md:relative md:w-72 md:translate-x-0",
-            sidebarOpen ? "translate-x-0" : "-translate-x-full",
-          )}
-        >
-          <Sidebar />
-        </div>
-
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <main className="neo-scroll flex-1 overflow-hidden pb-[calc(5rem+env(safe-area-inset-bottom))] md:pb-0">
-            <Outlet />
-          </main>
-
-          <MobileHeader
-            sidebarOpen={sidebarOpen}
-            onToggleSidebar={() => setSidebarOpen((currentOpen) => !currentOpen)}
+    <AppQueryProvider>
+      <RunnerSessionsProvider>
+        <div className="neo-enter flex h-dvh bg-background text-foreground">
+          <div
+            className={cn(
+              "fixed inset-0 z-40 bg-[rgb(18_18_18_/_0.32)] backdrop-blur-[1px] transition-opacity md:hidden",
+              sidebarOpen ? "opacity-100" : "opacity-0 pointer-events-none",
+            )}
+            onClick={() => setSidebarOpen(false)}
           />
+
+          <div
+            className={cn(
+              "fixed inset-y-0 left-0 z-50 w-full max-w-full overflow-hidden border-r border-border bg-card transition-transform duration-200 ease-in-out",
+              "md:relative md:w-72 md:translate-x-0",
+              sidebarOpen ? "translate-x-0" : "-translate-x-full",
+            )}
+          >
+            <Sidebar />
+          </div>
+
+          <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+            <main className="neo-scroll flex-1 overflow-hidden pb-[calc(5rem+env(safe-area-inset-bottom))] md:pb-0">
+              <Outlet />
+            </main>
+
+            <MobileHeader
+              sidebarOpen={sidebarOpen}
+              onToggleSidebar={() => setSidebarOpen((currentOpen) => !currentOpen)}
+            />
+          </div>
         </div>
-      </div>
-    </RunnerSessionsProvider>
+      </RunnerSessionsProvider>
+    </AppQueryProvider>
   );
 }

--- a/src/components/task-model-picker.tsx
+++ b/src/components/task-model-picker.tsx
@@ -1,0 +1,100 @@
+import { ChevronDown, Loader2 } from "lucide-react";
+import type { DesktopRunnerModelSelection } from "@/lib/desktop-runner";
+import {
+  getRunnerModelOptionGroups,
+  parseRunnerModelSelection,
+  serializeRunnerModelSelection,
+  type RunnerModelOption,
+} from "@/lib/runner-models";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+type TaskModelPickerProps = {
+  disabled?: boolean;
+  error?: string | null;
+  isLoading?: boolean;
+  onChange: (selection: DesktopRunnerModelSelection | null) => void;
+  options: RunnerModelOption[];
+  value: DesktopRunnerModelSelection | null;
+};
+
+export function TaskModelPicker({
+  disabled = false,
+  error = null,
+  isLoading = false,
+  onChange,
+  options,
+  value,
+}: TaskModelPickerProps) {
+  const hasOptions = options.length > 0;
+  const optionGroups = getRunnerModelOptionGroups(options);
+  const selectedValue = serializeRunnerModelSelection(value);
+  const selectedOption = options.find((option) => option.value === selectedValue) ?? null;
+  const placeholder = isLoading
+    ? "Loading models..."
+    : error
+      ? "Model list unavailable"
+      : hasOptions
+        ? "Select a model"
+        : "No runner models";
+
+  return (
+    <div className="flex min-w-0 flex-col gap-1">
+      <div className="flex items-center gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={disabled || isLoading || !hasOptions}
+              className={cn(
+                "border-input hover:bg-input flex h-9 min-w-[220px] max-w-full justify-between rounded-[var(--radius-sm)] bg-input px-3 text-sm font-medium normal-case tracking-normal shadow-[2px_2px_0_0_var(--color-border)]",
+                "focus-visible:ring-2 focus-visible:ring-ring/50",
+                !selectedOption && "text-muted-foreground",
+              )}
+            >
+              <span className="truncate">{selectedOption?.label ?? placeholder}</span>
+              {isLoading ? (
+                <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
+              ) : (
+                <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              )}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            side="top"
+            className="max-h-80 w-[min(24rem,var(--radix-dropdown-menu-trigger-width))]"
+          >
+            <DropdownMenuRadioGroup
+              value={selectedValue}
+              onValueChange={(nextValue) => onChange(parseRunnerModelSelection(nextValue, options))}
+            >
+              {optionGroups.map((group, index) => (
+                <div key={group.provider}>
+                  {index > 0 ? <DropdownMenuSeparator /> : null}
+                  <DropdownMenuLabel>{group.providerName}</DropdownMenuLabel>
+                  {group.options.map((option) => (
+                    <DropdownMenuRadioItem key={option.value} value={option.value}>
+                      {option.modelName}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </div>
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/lib/desktop-runner.ts
+++ b/src/lib/desktop-runner.ts
@@ -4,18 +4,38 @@ type CreateDesktopRunnerSessionResponse = {
   workspaceDirectory: string;
 };
 
+export type DesktopRunnerModelSelection = {
+  model: string;
+  provider: string;
+};
+
+export type DesktopRunnerModelProvider = {
+  id: string;
+  models: Record<string, { id: string; name: string }>;
+  name: string;
+};
+
+export type ListDesktopRunnerModelsResponse = {
+  connected: string[];
+  default: Record<string, string>;
+  providers: DesktopRunnerModelProvider[];
+};
+
 type DesktopRunnerBridge = {
   createRunnerSession: (
     title: string,
     repoUrl: string,
   ) => Promise<CreateDesktopRunnerSessionResponse>;
   deleteRunnerWorkspace: (workspaceDirectory: string) => Promise<void>;
+  listRunnerModels: (args: { directory: string }) => Promise<ListDesktopRunnerModelsResponse>;
   promptRunnerTask: (args: {
     backendBaseUrl: string;
     callbackToken: string;
     directory: string;
     executionId: string;
+    model?: string;
     prompt: string;
+    provider?: string;
     sessionId: string;
   }) => Promise<void>;
 };
@@ -45,12 +65,20 @@ export async function deleteDesktopRunnerWorkspace(workspaceDirectory: string): 
   await getDesktopRunnerBridge().deleteRunnerWorkspace(workspaceDirectory);
 }
 
+export async function listDesktopRunnerModels(args: {
+  directory: string;
+}): Promise<ListDesktopRunnerModelsResponse> {
+  return await getDesktopRunnerBridge().listRunnerModels(args);
+}
+
 export async function promptDesktopRunnerTask(args: {
   backendBaseUrl: string;
   callbackToken: string;
   directory: string;
   executionId: string;
+  model?: string;
   prompt: string;
+  provider?: string;
   sessionId: string;
 }): Promise<void> {
   await getDesktopRunnerBridge().promptRunnerTask(args);

--- a/src/lib/runner-models.ts
+++ b/src/lib/runner-models.ts
@@ -1,0 +1,168 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  listDesktopRunnerModels,
+  type DesktopRunnerModelSelection,
+  type ListDesktopRunnerModelsResponse,
+} from "@/lib/desktop-runner";
+import { isDesktopApp } from "@/lib/is-desktop-app";
+
+export type RunnerModelOption = {
+  label: string;
+  model: string;
+  modelName: string;
+  provider: string;
+  providerName: string;
+  value: string;
+};
+
+export type RunnerModelOptionGroup = {
+  options: RunnerModelOption[];
+  provider: string;
+  providerName: string;
+};
+
+const RUNNER_MODELS_QUERY_KEY = ["runner-models"] as const;
+
+export function useRunnerModels(directory: string | null) {
+  const desktopApp = isDesktopApp();
+  const normalizedDirectory = directory?.trim() ?? "";
+
+  return useQuery({
+    queryKey: RUNNER_MODELS_QUERY_KEY,
+    queryFn: async () =>
+      await listDesktopRunnerModels({
+        directory: normalizedDirectory,
+      }),
+    enabled: desktopApp && normalizedDirectory.length > 0,
+    gcTime: Number.POSITIVE_INFINITY,
+    refetchOnWindowFocus: false,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+}
+
+export function getDefaultRunnerModelSelection(
+  response: ListDesktopRunnerModelsResponse | undefined,
+): DesktopRunnerModelSelection | null {
+  const options = getRunnerModelOptions(response);
+
+  if (options.length === 0) {
+    return null;
+  }
+
+  const defaultProviderId = response?.connected.find((providerId) =>
+    options.some((option) => option.provider === providerId),
+  );
+
+  if (defaultProviderId) {
+    const defaultModelId = response?.default[defaultProviderId];
+    if (defaultModelId) {
+      const defaultOption = options.find(
+        (option) => option.provider === defaultProviderId && option.model === defaultModelId,
+      );
+
+      if (defaultOption) {
+        return toRunnerModelSelection(defaultOption);
+      }
+    }
+  }
+
+  return toRunnerModelSelection(options[0]);
+}
+
+export function getRunnerModelOptions(
+  response: ListDesktopRunnerModelsResponse | undefined,
+): RunnerModelOption[] {
+  if (!response || response.connected.length === 0) {
+    return [];
+  }
+
+  const connectedProviderIds = new Set(response.connected);
+
+  return response.providers
+    .filter((provider) => connectedProviderIds.has(provider.id))
+    .toSorted(
+      (left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id),
+    )
+    .flatMap((provider) =>
+      Object.values(provider.models)
+        .toSorted(
+          (left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id),
+        )
+        .map((model) => ({
+          label: `${provider.name} · ${model.name}`,
+          model: model.id,
+          modelName: model.name,
+          provider: provider.id,
+          providerName: provider.name,
+          value: serializeRunnerModelSelection({
+            model: model.id,
+            provider: provider.id,
+          }),
+        })),
+    );
+}
+
+export function getRunnerModelOptionGroups(options: RunnerModelOption[]): RunnerModelOptionGroup[] {
+  const groups = new Map<string, RunnerModelOptionGroup>();
+
+  for (const option of options) {
+    const existingGroup = groups.get(option.provider);
+    if (existingGroup) {
+      existingGroup.options.push(option);
+      continue;
+    }
+
+    groups.set(option.provider, {
+      options: [option],
+      provider: option.provider,
+      providerName: option.providerName,
+    });
+  }
+
+  return [...groups.values()];
+}
+
+export function isRunnerModelSelectionAvailable(
+  selection: DesktopRunnerModelSelection | null,
+  options: RunnerModelOption[],
+): boolean {
+  if (!selection) {
+    return false;
+  }
+
+  return options.some(
+    (option) => option.model === selection.model && option.provider === selection.provider,
+  );
+}
+
+export function parseRunnerModelSelection(
+  value: string,
+  options: RunnerModelOption[],
+): DesktopRunnerModelSelection | null {
+  const option = options.find((candidate) => candidate.value === value);
+  return option ? toRunnerModelSelection(option) : null;
+}
+
+export function serializeRunnerModelSelection(
+  selection: DesktopRunnerModelSelection | null,
+): string {
+  if (!selection) {
+    return "";
+  }
+
+  return `${selection.provider}:${selection.model}`;
+}
+
+export function selectionsMatch(
+  left: DesktopRunnerModelSelection | null,
+  right: DesktopRunnerModelSelection | null,
+): boolean {
+  return left?.model === right?.model && left?.provider === right?.provider;
+}
+
+function toRunnerModelSelection(option: RunnerModelOption): DesktopRunnerModelSelection {
+  return {
+    model: option.model,
+    provider: option.provider,
+  };
+}

--- a/src/lib/session-state.ts
+++ b/src/lib/session-state.ts
@@ -98,4 +98,6 @@ function canUseSessionStorage(): boolean {
 
 export const sessionStateKeys = {
   taskInput: (taskId: string) => createSessionStateKey<string>(`task-input:${taskId}`),
+  taskModel: (taskId: string) =>
+    createSessionStateKey<{ model: string; provider: string } | null>(`task-model:${taskId}`),
 };

--- a/src/pages/task-page.tsx
+++ b/src/pages/task-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { useLiveQuery, eq } from "@tanstack/react-db";
 import { AlertCircle, ChevronRight, ExternalLink, Loader2, Send, Wrench } from "lucide-react";
 import {
@@ -7,9 +7,17 @@ import {
   type TaskStreamActivityItem,
 } from "@/components/task-stream-activity";
 import { MarkdownContent } from "@/components/markdown-content";
+import { TaskModelPicker } from "@/components/task-model-picker";
 import { Button } from "@/components/ui/button";
 import { promptDesktopRunnerTask } from "@/lib/desktop-runner";
 import { isDesktopApp } from "@/lib/is-desktop-app";
+import {
+  getDefaultRunnerModelSelection,
+  getRunnerModelOptions,
+  isRunnerModelSelectionAvailable,
+  selectionsMatch,
+  useRunnerModels,
+} from "@/lib/runner-models";
 import { Textarea } from "@/components/ui/textarea";
 import { sessionStateKeys, useSessionState } from "@/lib/session-state";
 import { cn } from "@/lib/utils";
@@ -161,6 +169,10 @@ export function TaskPage({
 }: TaskPageProps) {
   const displayTitle = branchName ?? title;
   const [input, setInput] = useSessionState(sessionStateKeys.taskInput(taskId), "");
+  const [selectedModel, setSelectedModel] = useSessionState(
+    sessionStateKeys.taskModel(taskId),
+    null,
+  );
   const [localError, setLocalError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const runEvents = useTaskEventStream({ taskId, streamId });
@@ -196,6 +208,18 @@ export function TaskPage({
   const isRunnerBackedTask =
     runnerType === "local-worktree" && !!runnerSessionId && !!workspacePath;
   const isReadOnlyRemoteTask = isRunnerBackedTask && !desktopApp;
+  const {
+    data: runnerModels,
+    error: runnerModelsError,
+    isLoading: isRunnerModelsLoading,
+  } = useRunnerModels(isRunnerBackedTask ? workspacePath : null);
+  const availableModelOptions = getRunnerModelOptions(runnerModels);
+  const defaultModelSelection = getDefaultRunnerModelSelection(runnerModels);
+  const activeModelSelection = isRunnerModelSelectionAvailable(selectedModel, availableModelOptions)
+    ? selectedModel
+    : defaultModelSelection;
+  const runnerModelErrorMessage =
+    runnerModelsError instanceof Error ? runnerModelsError.message : null;
   const displayError = localError ?? error;
 
   useEffect(() => {
@@ -231,6 +255,14 @@ export function TaskPage({
       globalThis.clearInterval(timerId);
     };
   }, [isRunning]);
+
+  useEffect(() => {
+    if (selectionsMatch(selectedModel, activeModelSelection)) {
+      return;
+    }
+
+    setSelectedModel(activeModelSelection);
+  }, [activeModelSelection, selectedModel, setSelectedModel]);
 
   async function handleSend(contentOverride?: string) {
     const content = (contentOverride ?? input).trim();
@@ -284,7 +316,9 @@ export function TaskPage({
           callbackToken: taskRun.callbackToken,
           directory: workspacePath,
           executionId: taskRun.executionId,
+          model: activeModelSelection?.model,
           prompt: content,
+          provider: activeModelSelection?.provider,
           sessionId: runnerSessionId,
         });
       }
@@ -306,7 +340,7 @@ export function TaskPage({
     }
   }
 
-  function handleKeyDown(e: React.KeyboardEvent) {
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       void handleSend();
@@ -495,7 +529,7 @@ export function TaskPage({
       </div>
 
       <div className="shrink-0 border-t border-border bg-card p-4">
-        <div className="flex items-end gap-2">
+        <div className="rounded-[var(--radius-md)] border border-border bg-background shadow-[3px_3px_0_0_var(--color-border)]">
           <Textarea
             ref={inputRef}
             value={input}
@@ -508,24 +542,48 @@ export function TaskPage({
                   ? "Wait for the current run to finish..."
                   : "Send a message..."
             }
-            rows={1}
+            rows={4}
             disabled={isRunning || isReadOnlyRemoteTask || sending}
-            className="min-h-[42px] max-h-[200px] flex-1 resize-none rounded-[var(--radius-md)] px-4 py-2.5 text-base md:text-sm"
+            className="min-h-[120px] max-h-[240px] resize-none rounded-none border-0 bg-transparent px-4 py-4 text-base leading-relaxed shadow-none focus-visible:ring-0 md:text-sm"
             style={{ height: "auto" }}
             onInput={(e) => {
               const target = e.target as HTMLTextAreaElement;
               target.style.height = "auto";
-              target.style.height = Math.min(target.scrollHeight, 200) + "px";
+              target.style.height = Math.min(target.scrollHeight, 240) + "px";
             }}
           />
-          <Button
-            type="button"
-            onClick={() => void handleSend()}
-            disabled={!input.trim() || isReadOnlyRemoteTask || sending || isRunning}
-            className="h-[42px] w-[42px] shrink-0 rounded-[var(--radius-md)] p-0"
-          >
-            {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
-          </Button>
+          <div className="flex flex-wrap items-end justify-between gap-3 px-4 pt-0 pb-4">
+            {isRunnerBackedTask && desktopApp ? (
+              <TaskModelPicker
+                value={activeModelSelection}
+                onChange={setSelectedModel}
+                options={availableModelOptions}
+                isLoading={isRunnerModelsLoading}
+                error={
+                  runnerModelErrorMessage ??
+                  (!isRunnerModelsLoading && availableModelOptions.length === 0
+                    ? "No connected OpenCode providers were found in the runner."
+                    : null)
+                }
+                disabled={isReadOnlyRemoteTask || sending || isRunning}
+              />
+            ) : null}
+            <Button
+              type="button"
+              onClick={() => void handleSend()}
+              disabled={!input.trim() || isReadOnlyRemoteTask || sending || isRunning}
+              className={cn(
+                "h-[42px] w-[42px] shrink-0 rounded-[var(--radius-md)] p-0",
+                !(isRunnerBackedTask && desktopApp) && "ml-auto",
+              )}
+            >
+              {sending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This adds runner model listing and optional model/provider selection plumbing from the Electron shell through the local runner task prompt APIs. It introduces a React Query provider plus runner model helpers so runner-backed tasks can load available OpenCode models, persist the current selection per task, and fall back to the runner default. It adds a grouped model picker to the task composer and reshapes the composer into a larger floating input with footer controls. It also removes the hardcoded OpenCode model/provider when creating assistant sessions so tasks can use the selected runner model or the runner default.