### PR TITLE
Hide provider name in model dropdown button

### DIFF
--- a/src/components/task-model-picker.tsx
+++ b/src/components/task-model-picker.tsx
@@ -62,7 +62,7 @@ export function TaskModelPicker({
                 !selectedOption && "text-muted-foreground",
               )}
             >
-              <span className="truncate">{selectedOption?.label ?? placeholder}</span>
+              <span className="truncate">{selectedOption?.modelName ?? placeholder}</span>
               {isLoading ? (
                 <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
               ) : (


### PR DESCRIPTION
Show only the model name (e.g. "Opus 4.6") instead of the full label with provider (e.g. "anthropic · Opus 4.6"). The provider name is still visible as a group label inside the dropdown menu.

🤖 Generated with Claude Code