### PR TITLE
Start workspaces from main snapshot

### DIFF
--- a/packages/runner/src/task-assistant-session.ts
+++ b/packages/runner/src/task-assistant-session.ts
@@ -2,6 +2,9 @@ import type { Event as OpenCodeEvent, OpencodeClient, TextPart } from "@opencode
 import { createLocalRunnerOpencodeClient } from "./opencode-client";
 import { promptAssistantSession } from "./assistant-session";
 
+const DEFAULT_FIRST_TASK_INSTRUCTION =
+  "Before doing any work, create and switch to a dedicated git branch for this task if you are not already on one. If the workspace is already on a dedicated task branch, keep using it. Do all work for this task on that branch.";
+
 type TaskRunCallbackInfo = {
   backendBaseUrl: string;
   callbackToken: string;
@@ -34,11 +37,17 @@ export async function promptTaskAssistantSession(args: {
       stream: eventStream.stream,
       taskRun: args.taskRun,
     });
+    const prompt = await buildTaskPrompt({
+      client,
+      directory: args.directory,
+      prompt: args.prompt,
+      sessionId: args.sessionId,
+    });
 
     await promptAssistantSession({
       directory: args.directory,
       model: args.model,
-      prompt: args.prompt,
+      prompt,
       provider: args.provider,
       sessionId: args.sessionId,
     });
@@ -81,6 +90,44 @@ export async function promptTaskAssistantSession(args: {
   } finally {
     abortController.abort();
   }
+}
+
+async function buildTaskPrompt(args: {
+  client: OpencodeClient;
+  directory: string;
+  prompt: string;
+  sessionId: string;
+}): Promise<string> {
+  const hasConversation = await sessionHasConversation(args);
+
+  if (hasConversation) {
+    return args.prompt;
+  }
+
+  return `${DEFAULT_FIRST_TASK_INSTRUCTION}\n\nTask:\n${args.prompt}`;
+}
+
+async function sessionHasConversation(args: {
+  client: OpencodeClient;
+  directory: string;
+  sessionId: string;
+}): Promise<boolean> {
+  const response = await args.client.session.messages({
+    path: { id: args.sessionId },
+    query: {
+      directory: args.directory,
+      limit: 20,
+    },
+  });
+
+  if (!response.response.ok || !response.data) {
+    return false;
+  }
+
+  return response.data.some((message) => {
+    const role = message.info.role;
+    return role === "user" || role === "assistant";
+  });
 }
 
 async function relayTaskRunEvents(args: {

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -9,7 +9,6 @@ type CreateWorkspaceArgs = {
 };
 
 type PreparedWorkspace = {
-  branchName: string;
   defaultDirectory: string;
   directory: string;
 };
@@ -33,7 +32,6 @@ export function deleteWorkspace(workspaceDirectory: string): void {
   const defaultDirectory = resolveRepoDefaultDirectory(managedWorkspaceDirectory);
 
   if (!fs.existsSync(managedWorkspaceDirectory)) {
-    removeManagedWorktreeBranch(managedWorkspaceDirectory);
     return;
   }
 
@@ -47,8 +45,6 @@ export function deleteWorkspace(workspaceDirectory: string): void {
     ["-C", defaultDirectory, "worktree", "remove", "--force", managedWorkspaceDirectory],
     `Failed to remove the worktree at ${managedWorkspaceDirectory}`,
   );
-
-  removeManagedWorktreeBranch(managedWorkspaceDirectory);
 }
 
 function prepareSessionWorktree(repoUrl: string, title: string): PreparedWorkspace {
@@ -56,7 +52,6 @@ function prepareSessionWorktree(repoUrl: string, title: string): PreparedWorkspa
   const defaultBranch = ensureDefaultCheckout(repoUrl, workspace);
   const identifier = nextWorktreeIdentifier(workspace.repoRoot, title);
   const directory = path.join(workspace.repoRoot, identifier);
-  const branchName = `runner/${identifier}`;
 
   runCommand(
     "git",
@@ -65,35 +60,17 @@ function prepareSessionWorktree(repoUrl: string, title: string): PreparedWorkspa
       workspace.defaultDirectory,
       "worktree",
       "add",
-      "-b",
-      branchName,
+      "--detach",
       directory,
-      defaultBranch,
+      `origin/${defaultBranch}`,
     ],
     `Failed to create a worktree at ${directory}`,
   );
 
   return {
-    branchName,
     defaultDirectory: workspace.defaultDirectory,
     directory,
   };
-}
-
-function removeManagedWorktreeBranch(workspaceDirectory: string): void {
-  const defaultDirectory = resolveRepoDefaultDirectory(workspaceDirectory);
-
-  if (!fs.existsSync(defaultDirectory)) {
-    return;
-  }
-
-  try {
-    runCommand(
-      "git",
-      ["-C", defaultDirectory, "branch", "-D", resolveManagedBranchName(workspaceDirectory)],
-      undefined,
-    );
-  } catch {}
 }
 
 function ensureDefaultCheckout(repoUrl: string, workspace: RepoWorkspacePaths): string {
@@ -225,10 +202,6 @@ function resolveManagedWorkspaceDirectory(workspaceDirectory: string): string {
 
 function resolveRepoDefaultDirectory(workspaceDirectory: string): string {
   return path.join(path.dirname(workspaceDirectory), "default");
-}
-
-function resolveManagedBranchName(workspaceDirectory: string): string {
-  return `runner/${path.basename(workspaceDirectory)}`;
 }
 
 function parseRepoSlug(repoUrl: string): string {


### PR DESCRIPTION
This changes runner workspace setup to create detached worktrees from the latest origin/main snapshot instead of auto-creating runner/<id> branches. It also prepends a default instruction on the first task prompt telling the agent to create and work on a dedicated branch before making changes. The old managed-branch cleanup paths are removed accordingly.