### PR TITLE
Run project setup commands in new workspaces

### DIFF
--- a/packages/desktop-shell/src/desktop-runner.mts
+++ b/packages/desktop-shell/src/desktop-runner.mts
@@ -26,6 +26,7 @@ const DESKTOP_EDITOR_COMMANDS = {
 
 type CreateRunnerSessionArgs = {
   repoUrl: string;
+  setupCommand?: string;
   title: string;
 };
 
@@ -101,7 +102,11 @@ export function createDesktopRunnerController({
 }): AppRunnerController {
   let runnerProcess: RunnerProcess | null = null;
 
-  async function createRunnerSession({ repoUrl, title }: CreateRunnerSessionArgs): Promise<{
+  async function createRunnerSession({
+    repoUrl,
+    setupCommand,
+    title,
+  }: CreateRunnerSessionArgs): Promise<{
     runnerType: string;
     sessionId: string;
     workspaceDirectory: string;
@@ -118,6 +123,7 @@ export function createDesktopRunnerController({
         model: DEFAULT_OPENCODE_MODEL,
         provider: DEFAULT_OPENCODE_PROVIDER,
         repoUrl,
+        setupCommand,
         taskTitle: trimmedTitle,
       },
     );

--- a/packages/desktop-shell/src/preload.mts
+++ b/packages/desktop-shell/src/preload.mts
@@ -1,8 +1,8 @@
 import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld("clankiDesktop", {
-  createRunnerSession(title: string, repoUrl: string) {
-    return ipcRenderer.invoke("desktop-runner:create-session", { repoUrl, title });
+  createRunnerSession(title: string, repoUrl: string, setupCommand?: string) {
+    return ipcRenderer.invoke("desktop-runner:create-session", { repoUrl, setupCommand, title });
   },
   deleteRunnerWorkspace(workspaceDirectory: string) {
     return ipcRenderer.invoke("desktop-runner:delete-workspace", { workspaceDirectory });

--- a/packages/runner/src/local-runner-protocol.ts
+++ b/packages/runner/src/local-runner-protocol.ts
@@ -30,6 +30,7 @@ export type CreateAssistantSessionRequest = {
   model: string;
   provider: string;
   repoUrl: string;
+  setupCommand?: string;
   taskTitle: string;
 };
 

--- a/packages/runner/src/local-runner-server.ts
+++ b/packages/runner/src/local-runner-server.ts
@@ -14,6 +14,7 @@ import {
   type PromptTaskAssistantSessionRequest,
 } from "./local-runner-protocol";
 import { listOpencodeModels } from "./opencode-models";
+import { runSetupCommand } from "./run-setup-command";
 import { promptTaskAssistantSession } from "./task-assistant-session";
 import { createWorkspace, deleteWorkspace } from "./workspace";
 
@@ -84,6 +85,13 @@ export function createLocalRunnerApp(): Hono {
     });
 
     try {
+      if (typeof body.setupCommand === "string") {
+        runSetupCommand({
+          command: body.setupCommand,
+          directory: workspaceDirectory,
+        });
+      }
+
       const session = await ensureAssistantSession({
         directory: workspaceDirectory,
         existingSessionId: null,

--- a/packages/runner/src/run-setup-command.ts
+++ b/packages/runner/src/run-setup-command.ts
@@ -1,0 +1,37 @@
+import { spawnSync } from "node:child_process";
+
+type RunSetupCommandArgs = {
+  command: string;
+  directory: string;
+};
+
+export function runSetupCommand({ command, directory }: RunSetupCommandArgs): void {
+  const trimmedCommand = command.trim();
+  if (trimmedCommand.length === 0) {
+    return;
+  }
+
+  const output = spawnSync("/bin/sh", ["-lc", trimmedCommand], {
+    cwd: directory,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (output.error) {
+    throw new Error(`Failed to run setup command "${trimmedCommand}": ${output.error.message}`);
+  }
+
+  if (output.status === 0) {
+    return;
+  }
+
+  const stderr = output.stderr.trim();
+  const stdout = output.stdout.trim();
+  const details = stderr || stdout;
+
+  throw new Error(
+    details.length > 0
+      ? `Setup command failed in ${directory}: ${details}`
+      : `Setup command failed in ${directory} with exit code ${output.status ?? "unknown"}`,
+  );
+}

--- a/src/components/new-task-button.tsx
+++ b/src/components/new-task-button.tsx
@@ -51,7 +51,7 @@ export function NewTaskButton({ iconOnly = false, title, ...props }: NewTaskButt
     navigate({ to: "/tasks/$taskId", params: { taskId } });
     setCreating(false);
 
-    createDesktopRunnerSession(taskTitle, repoUrl)
+    createDesktopRunnerSession(taskTitle, repoUrl, defaultProject.setup_command ?? undefined)
       .then((response) => {
         tasksCollection.update(taskId, (draft) => {
           draft.runner_type = response.runnerType;

--- a/src/lib/desktop-runner.ts
+++ b/src/lib/desktop-runner.ts
@@ -27,6 +27,7 @@ type DesktopRunnerBridge = {
   createRunnerSession: (
     title: string,
     repoUrl: string,
+    setupCommand?: string,
   ) => Promise<CreateDesktopRunnerSessionResponse>;
   deleteRunnerWorkspace: (workspaceDirectory: string) => Promise<void>;
   listRunnerModels: (args: { directory: string }) => Promise<ListDesktopRunnerModelsResponse>;
@@ -63,8 +64,9 @@ function getDesktopRunnerBridge(): DesktopRunnerBridge {
 export async function createDesktopRunnerSession(
   title: string,
   repoUrl: string,
+  setupCommand?: string,
 ): Promise<{ runnerType: string; sessionId: string; workspaceDirectory: string }> {
-  return await getDesktopRunnerBridge().createRunnerSession(title, repoUrl);
+  return await getDesktopRunnerBridge().createRunnerSession(title, repoUrl, setupCommand);
 }
 
 export async function deleteDesktopRunnerWorkspace(workspaceDirectory: string): Promise<void> {


### PR DESCRIPTION
## Summary
Run the saved project setup command after a local runner workspace is created and before the assistant session starts.
Pass the optional setup command through the desktop bridge from both task creation entry points.
Keep the existing cleanup behavior so failed setup commands delete the workspace and return the error.

## Verification
bun run format
bun run lint:fix
bun run knip
bun run build