### PR TITLE
Remember last used model across sessions

### DIFF
--- a/src/lib/session-state.ts
+++ b/src/lib/session-state.ts
@@ -2,49 +2,56 @@ import { useEffect, useState } from "react";
 
 type SetStateAction<T> = T | ((previousState: T) => T);
 
-export type SessionStateKey<T> = {
+type BrowserStorageKind = "local" | "session";
+
+export type StorageStateKey<T> = {
+  storage: BrowserStorageKind;
   storageKey: string;
   parse: (rawValue: string) => T;
   serialize: (value: T) => string;
 };
 
-function createSessionStateKey<T>(
+function createStorageStateKey<T>(
+  storage: BrowserStorageKind,
   storageKey: string,
   options?: {
     parse?: (rawValue: string) => T;
     serialize?: (value: T) => string;
   },
-): SessionStateKey<T> {
+): StorageStateKey<T> {
   return {
+    storage,
     storageKey,
     parse: options?.parse ?? defaultParse,
     serialize: options?.serialize ?? defaultSerialize,
   };
 }
 
-export function useSessionState<T>(
-  key: SessionStateKey<T>,
+function useStorageState<T>(
+  key: StorageStateKey<T>,
   initialState: T | (() => T),
 ): [T, (nextState: SetStateAction<T>) => void] {
-  const { parse, serialize, storageKey } = key;
+  const { parse, serialize, storage, storageKey } = key;
   const [state, setState] = useState<T>(() =>
-    getInitialSessionState(storageKey, parse, initialState),
+    getInitialStorageState(storage, storageKey, parse, initialState),
   );
 
   useEffect(() => {
-    setState(getInitialSessionState(storageKey, parse, initialState));
-  }, [initialState, parse, storageKey]);
+    setState(getInitialStorageState(storage, storageKey, parse, initialState));
+  }, [initialState, parse, storage, storageKey]);
 
-  const setSessionState = (nextState: SetStateAction<T>) => {
+  const setStorageState = (nextState: SetStateAction<T>) => {
     setState((previousState) => {
       const resolvedState =
         typeof nextState === "function"
           ? (nextState as (previousState: T) => T)(previousState)
           : nextState;
 
-      if (canUseSessionStorage()) {
+      const browserStorage = getBrowserStorage(storage);
+
+      if (browserStorage) {
         try {
-          globalThis.sessionStorage.setItem(storageKey, serialize(resolvedState));
+          browserStorage.setItem(storageKey, serialize(resolvedState));
         } catch {
           return resolvedState;
         }
@@ -54,26 +61,42 @@ export function useSessionState<T>(
     });
   };
 
-  return [state, setSessionState];
+  return [state, setStorageState];
+}
+
+export function useSessionState<T>(
+  key: StorageStateKey<T>,
+  initialState: T | (() => T),
+): [T, (nextState: SetStateAction<T>) => void] {
+  return useStorageState(key, initialState);
+}
+
+export function useLocalStorageState<T>(
+  key: StorageStateKey<T>,
+  initialState: T | (() => T),
+): [T, (nextState: SetStateAction<T>) => void] {
+  return useStorageState(key, initialState);
 }
 
 function resolveInitialState<T>(initialState: T | (() => T)): T {
   return typeof initialState === "function" ? (initialState as () => T)() : initialState;
 }
 
-function getInitialSessionState<T>(
+function getInitialStorageState<T>(
+  storage: BrowserStorageKind,
   storageKey: string,
   parse: (rawValue: string) => T,
   initialState: T | (() => T),
 ): T {
   const resolvedInitialState = resolveInitialState(initialState);
+  const browserStorage = getBrowserStorage(storage);
 
-  if (!canUseSessionStorage()) {
+  if (!browserStorage) {
     return resolvedInitialState;
   }
 
   try {
-    const persistedValue = globalThis.sessionStorage.getItem(storageKey);
+    const persistedValue = browserStorage.getItem(storageKey);
     if (persistedValue === null) {
       return resolvedInitialState;
     }
@@ -92,12 +115,27 @@ function defaultSerialize<T>(value: T): string {
   return JSON.stringify(value);
 }
 
-function canUseSessionStorage(): boolean {
-  return typeof window !== "undefined";
+function getBrowserStorage(storage: BrowserStorageKind): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  return storage === "local" ? globalThis.localStorage : globalThis.sessionStorage;
 }
 
 export const sessionStateKeys = {
-  taskInput: (taskId: string) => createSessionStateKey<string>(`task-input:${taskId}`),
+  taskInput: (taskId: string) => createStorageStateKey<string>("session", `task-input:${taskId}`),
   taskModel: (taskId: string) =>
-    createSessionStateKey<{ model: string; provider: string } | null>(`task-model:${taskId}`),
+    createStorageStateKey<{ model: string; provider: string } | null>(
+      "session",
+      `task-model:${taskId}`,
+    ),
+};
+
+export const localStorageKeys = {
+  lastUsedTaskModel: () =>
+    createStorageStateKey<{ model: string; provider: string } | null>(
+      "local",
+      "last-used-task-model",
+    ),
 };

--- a/src/pages/task-page.tsx
+++ b/src/pages/task-page.tsx
@@ -12,6 +12,12 @@ import { Button } from "@/components/ui/button";
 import { promptDesktopRunnerTask } from "@/lib/desktop-runner";
 import { isDesktopApp } from "@/lib/is-desktop-app";
 import {
+  localStorageKeys,
+  sessionStateKeys,
+  useLocalStorageState,
+  useSessionState,
+} from "@/lib/session-state";
+import {
   getDefaultRunnerModelSelection,
   getRunnerModelOptions,
   isRunnerModelSelectionAvailable,
@@ -19,7 +25,6 @@ import {
   useRunnerModels,
 } from "@/lib/runner-models";
 import { Textarea } from "@/components/ui/textarea";
-import { sessionStateKeys, useSessionState } from "@/lib/session-state";
 import { cn } from "@/lib/utils";
 import { startTaskRun } from "@/server/functions/task-runs";
 import type { Event as OpenCodeEvent } from "@opencode-ai/sdk";
@@ -173,6 +178,10 @@ export function TaskPage({
     sessionStateKeys.taskModel(taskId),
     null,
   );
+  const [lastUsedModel, setLastUsedModel] = useLocalStorageState(
+    localStorageKeys.lastUsedTaskModel(),
+    null,
+  );
   const [localError, setLocalError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const runEvents = useTaskEventStream({ taskId, streamId });
@@ -217,7 +226,9 @@ export function TaskPage({
   const defaultModelSelection = getDefaultRunnerModelSelection(runnerModels);
   const activeModelSelection = isRunnerModelSelectionAvailable(selectedModel, availableModelOptions)
     ? selectedModel
-    : defaultModelSelection;
+    : isRunnerModelSelectionAvailable(lastUsedModel, availableModelOptions)
+      ? lastUsedModel
+      : defaultModelSelection;
   const runnerModelErrorMessage =
     runnerModelsError instanceof Error ? runnerModelsError.message : null;
   const displayError = localError ?? error;
@@ -280,6 +291,10 @@ export function TaskPage({
     shouldStickToBottomRef.current = true;
     setSending(true);
     setLocalError(null);
+    if (!selectionsMatch(selectedModel, activeModelSelection)) {
+      setSelectedModel(activeModelSelection);
+    }
+    setLastUsedModel(activeModelSelection);
     if (contentOverride === undefined) {
       setInput("");
     }
@@ -556,7 +571,10 @@ export function TaskPage({
             {isRunnerBackedTask && desktopApp ? (
               <TaskModelPicker
                 value={activeModelSelection}
-                onChange={setSelectedModel}
+                onChange={(nextSelection) => {
+                  setSelectedModel(nextSelection);
+                  setLastUsedModel(nextSelection);
+                }}
                 options={availableModelOptions}
                 isLoading={isRunnerModelsLoading}
                 error={


### PR DESCRIPTION
Refactors storage utilities to support both session and local storage types. Users can now pick a model for a task, and that selection will be remembered across browser sessions as a fallback for future tasks. The model picker UI is also simplified by removing unnecessary option reordering logic.

Changes:
- Split storage utility into generic `useStorageState` with `useSessionState` and `useLocalStorageState` wrappers
- Store last selected model in localStorage with new `localStorageKeys.lastUsedTaskModel`
- Use last-used model as fallback when starting a new task (before defaulting to server-provided default)