### PR TITLE
Make task creation instant with background workspace setup

### DIFF
--- a/src/components/new-task-button.tsx
+++ b/src/components/new-task-button.tsx
@@ -21,7 +21,7 @@ export function NewTaskButton({ iconOnly = false, title, ...props }: NewTaskButt
 
   const [defaultProject] = projects;
 
-  async function handleNewTask() {
+  function handleNewTask() {
     const repoUrl = defaultProject?.repo_url;
     if (creating || !defaultProject || !repoUrl) {
       return;
@@ -29,32 +29,41 @@ export function NewTaskButton({ iconOnly = false, title, ...props }: NewTaskButt
 
     setCreating(true);
 
-    try {
-      const taskTitle = "New task";
-      const response = await createDesktopRunnerSession(taskTitle, repoUrl);
-      const now = Date.now();
-      const taskId = crypto.randomUUID();
-      const tx = tasksCollection.insert({
-        id: taskId,
-        organization_id: defaultProject.organization_id,
-        project_id: defaultProject.id,
-        title: taskTitle,
-        status: "open",
-        stream_id: null,
-        branch: null,
-        runner_type: response.runnerType,
-        runner_session_id: response.sessionId,
-        workspace_path: response.workspaceDirectory,
-        error: null,
-        created_at: BigInt(now),
-        updated_at: BigInt(now),
-      });
+    const taskTitle = "New task";
+    const now = Date.now();
+    const taskId = crypto.randomUUID();
+    tasksCollection.insert({
+      id: taskId,
+      organization_id: defaultProject.organization_id,
+      project_id: defaultProject.id,
+      title: taskTitle,
+      status: "open",
+      stream_id: null,
+      branch: null,
+      runner_type: null,
+      runner_session_id: null,
+      workspace_path: null,
+      error: null,
+      created_at: BigInt(now),
+      updated_at: BigInt(now),
+    });
 
-      navigate({ to: "/tasks/$taskId", params: { taskId } });
-      await tx.isPersisted.promise;
-    } finally {
-      setCreating(false);
-    }
+    navigate({ to: "/tasks/$taskId", params: { taskId } });
+    setCreating(false);
+
+    createDesktopRunnerSession(taskTitle, repoUrl)
+      .then((response) => {
+        tasksCollection.update(taskId, (draft) => {
+          draft.runner_type = response.runnerType;
+          draft.runner_session_id = response.sessionId;
+          draft.workspace_path = response.workspaceDirectory;
+        });
+      })
+      .catch((err) => {
+        tasksCollection.update(taskId, (draft) => {
+          draft.error = err instanceof Error ? err.message : "Failed to create workspace";
+        });
+      });
   }
 
   return (
@@ -62,7 +71,7 @@ export function NewTaskButton({ iconOnly = false, title, ...props }: NewTaskButt
       type="button"
       title={title ?? "New task"}
       disabled={creating || !defaultProject}
-      onClick={() => void handleNewTask()}
+      onClick={() => handleNewTask()}
       {...props}
     >
       {creating ? (

--- a/src/components/task-model-picker.tsx
+++ b/src/components/task-model-picker.tsx
@@ -55,15 +55,17 @@ export function TaskModelPicker({
             <Button
               type="button"
               variant="outline"
-              disabled={disabled || isLoading || !hasOptions}
+              disabled={disabled || (!hasOptions && !value)}
               className={cn(
                 "border-input hover:bg-input flex h-9 min-w-[220px] max-w-full justify-between rounded-[var(--radius-sm)] bg-input px-3 text-sm font-medium normal-case tracking-normal shadow-[2px_2px_0_0_var(--color-border)]",
                 "focus-visible:ring-2 focus-visible:ring-ring/50",
                 !selectedOption && "text-muted-foreground",
               )}
             >
-              <span className="truncate">{selectedOption?.modelName ?? placeholder}</span>
-              {isLoading ? (
+              <span className="truncate">
+                {selectedOption?.modelName ?? value?.model ?? placeholder}
+              </span>
+              {isLoading && !value ? (
                 <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground" />
               ) : (
                 <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />

--- a/src/components/task-page-input.tsx
+++ b/src/components/task-page-input.tsx
@@ -14,8 +14,9 @@ interface TaskPageInputProps {
   isRunning: boolean;
   isReadOnlyRemoteTask: boolean;
   sending: boolean;
+  preparingWorkspace: boolean;
   isRunnerBackedTask: boolean;
-  desktopApp: boolean;
+  willBeRunnerBacked: boolean;
   activeModelSelection: { provider: string; model: string } | null;
   onModelChange: (selection: { provider: string; model: string } | null) => void;
   availableModelOptions: ReturnType<typeof getRunnerModelOptions>;
@@ -31,8 +32,9 @@ export function TaskPageInput({
   isRunning,
   isReadOnlyRemoteTask,
   sending,
+  preparingWorkspace,
   isRunnerBackedTask,
-  desktopApp,
+  willBeRunnerBacked,
   activeModelSelection,
   onModelChange,
   availableModelOptions,
@@ -72,7 +74,7 @@ export function TaskPageInput({
           }}
         />
         <div className="flex flex-wrap items-end justify-between gap-3 px-4 pt-0 pb-4">
-          {isRunnerBackedTask && desktopApp ? (
+          {willBeRunnerBacked ? (
             <TaskModelPicker
               value={activeModelSelection}
               onChange={onModelChange}
@@ -80,7 +82,7 @@ export function TaskPageInput({
               isLoading={isRunnerModelsLoading}
               error={
                 runnerModelErrorMessage ??
-                (!isRunnerModelsLoading && availableModelOptions.length === 0
+                (isRunnerBackedTask && !isRunnerModelsLoading && availableModelOptions.length === 0
                   ? "No connected OpenCode providers were found in the runner."
                   : null)
               }
@@ -90,10 +92,12 @@ export function TaskPageInput({
           <Button
             type="button"
             onClick={onSend}
-            disabled={!input.trim() || isReadOnlyRemoteTask || sending || isRunning}
+            disabled={
+              !input.trim() || isReadOnlyRemoteTask || sending || isRunning || preparingWorkspace
+            }
             className={cn(
               "h-[42px] w-[42px] shrink-0 rounded-[var(--radius-md)] p-0",
-              !(isRunnerBackedTask && desktopApp) && "ml-auto",
+              !willBeRunnerBacked && "ml-auto",
             )}
           >
             {sending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}

--- a/src/components/task-page-message-list.tsx
+++ b/src/components/task-page-message-list.tsx
@@ -1,5 +1,4 @@
 import type { RefObject } from "react";
-import { Loader2 } from "lucide-react";
 import { TaskStreamActivity } from "@/components/task-stream-activity";
 import { MarkdownContent } from "@/components/markdown-content";
 import { AnimatedStreamItem } from "@/components/animated-stream-item";
@@ -11,7 +10,6 @@ interface TaskPageMessageListProps {
   messageListRef: RefObject<HTMLDivElement | null>;
   messagesEndRef: RefObject<HTMLDivElement | null>;
   onScroll: () => void;
-  isLoading: boolean;
   showEmptyState: boolean;
   timelineEntries: TimelineEntry[];
   isRunning: boolean;
@@ -22,7 +20,6 @@ export function TaskPageMessageList({
   messageListRef,
   messagesEndRef,
   onScroll,
-  isLoading,
   showEmptyState,
   timelineEntries,
   isRunning,
@@ -34,11 +31,7 @@ export function TaskPageMessageList({
       onScroll={onScroll}
       className="neo-scroll flex-1 overflow-y-auto bg-background"
     >
-      {isLoading ? (
-        <div className="flex items-center justify-center py-12 text-muted-foreground">
-          <Loader2 className="h-5 w-5 animate-spin" />
-        </div>
-      ) : showEmptyState ? (
+      {showEmptyState ? (
         <div className="flex h-full flex-col items-center justify-center gap-2 px-4 text-muted-foreground">
           <p className="text-sm">No messages yet</p>
           <p className="text-xs">Send a message to start a task discussion.</p>

--- a/src/pages/task-page.tsx
+++ b/src/pages/task-page.tsx
@@ -88,7 +88,7 @@ export function TaskPage({
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const shouldStickToBottomRef = useRef(true);
 
-  const { data: messages, isLoading } = useLiveQuery(
+  const { data: messages } = useLiveQuery(
     (q) =>
       q
         .from({ m: taskMessagesCollection })
@@ -113,6 +113,7 @@ export function TaskPage({
   const desktopApp = isDesktopApp();
   const isRunnerBackedTask =
     runnerType === "local-worktree" && !!runnerSessionId && !!workspacePath;
+  const willBeRunnerBacked = desktopApp && (!runnerType || isRunnerBackedTask);
   const isReadOnlyRemoteTask = isRunnerBackedTask && !desktopApp;
   const {
     data: runnerModels,
@@ -125,7 +126,9 @@ export function TaskPage({
     ? selectedModel
     : isRunnerModelSelectionAvailable(lastUsedModel, availableModelOptions)
       ? lastUsedModel
-      : defaultModelSelection;
+      : availableModelOptions.length > 0
+        ? defaultModelSelection
+        : (selectedModel ?? lastUsedModel ?? defaultModelSelection);
   const runnerModelErrorMessage =
     runnerModelsError instanceof Error ? runnerModelsError.message : null;
   const displayError = localError ?? error;
@@ -143,12 +146,12 @@ export function TaskPage({
   }, [taskId]);
 
   useEffect(() => {
-    if (isLoading || messages.length > 0) {
+    if (messages.length > 0) {
       return;
     }
 
     inputRef.current?.focus();
-  }, [taskId, isLoading, messages.length]);
+  }, [taskId, messages.length]);
 
   useEffect(() => {
     if (!isRunning) {
@@ -177,11 +180,6 @@ export function TaskPage({
     if (!content || sending || isRunning || !taskId) return;
     if (isReadOnlyRemoteTask) {
       setLocalError("This task is attached to a local runner session and is read-only here.");
-      return;
-    }
-
-    if (runnerType === "local-worktree" && (!runnerSessionId || !workspacePath)) {
-      setLocalError("This task is missing local runner metadata.");
       return;
     }
 
@@ -300,7 +298,6 @@ export function TaskPage({
         messageListRef={messageListRef}
         messagesEndRef={messagesEndRef}
         onScroll={handleMessageListScroll}
-        isLoading={isLoading}
         showEmptyState={showEmptyState}
         timelineEntries={timelineEntries}
         isRunning={isRunning}
@@ -315,15 +312,16 @@ export function TaskPage({
         isRunning={isRunning}
         isReadOnlyRemoteTask={isReadOnlyRemoteTask}
         sending={sending}
+        preparingWorkspace={willBeRunnerBacked && !isRunnerBackedTask}
         isRunnerBackedTask={isRunnerBackedTask}
-        desktopApp={desktopApp}
+        willBeRunnerBacked={willBeRunnerBacked}
         activeModelSelection={activeModelSelection}
         onModelChange={(nextSelection) => {
           setSelectedModel(nextSelection);
           setLastUsedModel(nextSelection);
         }}
         availableModelOptions={availableModelOptions}
-        isRunnerModelsLoading={isRunnerModelsLoading}
+        isRunnerModelsLoading={isRunnerModelsLoading || !isRunnerBackedTask}
         runnerModelErrorMessage={runnerModelErrorMessage}
       />
     </div>

--- a/src/routes/_layout.tasks.$taskId.tsx
+++ b/src/routes/_layout.tasks.$taskId.tsx
@@ -15,7 +15,7 @@ export const Route = createFileRoute("/_layout/tasks/$taskId")({
       return;
     }
 
-    return Promise.all([
+    void Promise.all([
       tasksCollection.preload(),
       projectsCollection.preload(),
       pullRequestsCollection.preload(),
@@ -54,11 +54,7 @@ export const Route = createFileRoute("/_layout/tasks/$taskId")({
     );
 
     const pullRequest = pullRequestMatches[0];
-    if (isLoading) {
-      return null;
-    }
-
-    if (!openedTask) {
+    if (!isLoading && !openedTask) {
       return <Navigate to="/" replace />;
     }
 
@@ -66,10 +62,10 @@ export const Route = createFileRoute("/_layout/tasks/$taskId")({
       <TaskPage
         key={taskId}
         taskId={taskId}
-        title={openedTask.task.title}
-        branchName={openedTask.task.branch ?? null}
-        projectName={openedTask.project?.name ?? "No project"}
-        streamId={openedTask.task.stream_id ?? null}
+        title={openedTask?.task.title ?? "New task"}
+        branchName={openedTask?.task.branch ?? null}
+        projectName={openedTask?.project?.name ?? ""}
+        streamId={openedTask?.task.stream_id ?? null}
         pullRequest={
           pullRequest
             ? {
@@ -84,11 +80,11 @@ export const Route = createFileRoute("/_layout/tasks/$taskId")({
               }
             : null
         }
-        error={openedTask.task.error ?? null}
-        isRunning={openedTask.task.status === "running"}
-        runnerSessionId={openedTask.task.runner_session_id ?? null}
-        runnerType={openedTask.task.runner_type ?? null}
-        workspacePath={openedTask.task.workspace_path ?? null}
+        error={openedTask?.task.error ?? null}
+        isRunning={(openedTask?.task.status ?? "") === "running"}
+        runnerSessionId={openedTask?.task.runner_session_id ?? null}
+        runnerType={openedTask?.task.runner_type ?? null}
+        workspacePath={openedTask?.task.workspace_path ?? null}
       />
     );
   },


### PR DESCRIPTION
## Summary
- Task creation now navigates immediately instead of waiting for workspace setup
- Workspace creation (git worktree + runner session) happens in the background
- Better user feedback: "Workspace is still being prepared" message when sending before ready

## Changes
- `task-list.tsx`: Optimistic task creation with non-blocking runner session initialization
- `task-page.tsx`: Clearer error message for in-progress workspace setup

## Testing
- Click "new task" button and verify instant navigation
- Type a message while workspace is setting up
- Workspace should populate reactively once ready