### PR TITLE
fix(runner): open the first available task by default

### DIFF
--- a/src/components/layout/task-list.tsx
+++ b/src/components/layout/task-list.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link, useNavigate, useRouterState } from "@tanstack/react-router";
+import { Link, useRouterState } from "@tanstack/react-router";
 import { useLiveQuery } from "@tanstack/react-db";
 import {
   CheckCheck,
@@ -7,10 +7,10 @@ import {
   GitPullRequest,
   Loader2,
   MessageSquare,
-  Plus,
   Trash2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { NewTaskButton } from "@/components/new-task-button";
 import {
   Dialog,
   DialogContent,
@@ -21,73 +21,12 @@ import {
 } from "@/components/ui/dialog";
 import { cn } from "../../lib/utils";
 import { projectsCollection, pullRequestsCollection, tasksCollection } from "../../lib/collections";
+import { deleteDesktopRunnerWorkspace } from "@/lib/desktop-runner";
 import {
-  extractOrgRepoFromUrl,
-  getPullRequestStatus,
-  type PullRequestStatus,
-} from "../../lib/pull-request";
-import { createDesktopRunnerSession, deleteDesktopRunnerWorkspace } from "@/lib/desktop-runner";
-
-type TaskSidebarGroup = "merged" | "needsAction" | "openNoPr" | "awaitingReview" | "running";
-
-const SIDEBAR_GROUPS: Array<{ key: TaskSidebarGroup; label: string }> = [
-  { key: "merged", label: "Merged" },
-  { key: "needsAction", label: "Needs action" },
-  { key: "openNoPr", label: "Open (no PR)" },
-  { key: "awaitingReview", label: "Awaiting review" },
-  { key: "running", label: "Running" },
-];
-
-const FAILING_CHECK_CONCLUSIONS = new Set([
-  "failure",
-  "cancelled",
-  "timed_out",
-  "action_required",
-  "startup_failure",
-  "stale",
-]);
-
-function hasFailingChecks(checksConclusion: string | null | undefined): boolean {
-  if (!checksConclusion) {
-    return false;
-  }
-
-  return FAILING_CHECK_CONCLUSIONS.has(checksConclusion);
-}
-
-function getSidebarGroupKey(params: {
-  taskStatus: string;
-  pullRequestStatus: PullRequestStatus | null;
-  reviewState: string | null | undefined;
-  checksConclusion: string | null | undefined;
-  hasError: boolean;
-}): TaskSidebarGroup {
-  const { taskStatus, pullRequestStatus, reviewState, checksConclusion, hasError } = params;
-
-  if (taskStatus === "running") {
-    return "running";
-  }
-
-  if (pullRequestStatus === "merged") {
-    return "merged";
-  }
-
-  if (
-    hasError ||
-    reviewState === "changes_requested" ||
-    hasFailingChecks(checksConclusion) ||
-    pullRequestStatus === "closed" ||
-    pullRequestStatus === "draft"
-  ) {
-    return "needsAction";
-  }
-
-  if (!pullRequestStatus) {
-    return "openNoPr";
-  }
-
-  return "awaitingReview";
-}
+  buildTaskSidebarGroups,
+  TASK_SIDEBAR_GROUPS,
+  type TaskSidebarGroup,
+} from "@/lib/task-sidebar";
 
 function renderGroupIcon(group: TaskSidebarGroup) {
   switch (group) {
@@ -115,88 +54,14 @@ export function TaskList() {
     query.from({ pr: pullRequestsCollection }).orderBy(({ pr }) => pr.opened_at, "desc"),
   );
 
-  const navigate = useNavigate();
   const pathname = useRouterState({ select: (state) => state.location.pathname });
-  const [creating, setCreating] = useState(false);
   const [deletingTask, setDeletingTask] = useState(false);
   const [taskToDelete, setTaskToDelete] = useState<{ id: string; title: string } | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const isSidebarLoading = isTasksLoading || isPullRequestsLoading;
 
-  const [defaultProject] = projects;
   const projectsById = new Map(projects.map((project) => [project.id, project]));
-  const latestPullRequestByKey = new Map<string, (typeof pullRequests)[number]>();
-
-  for (const pullRequest of pullRequests) {
-    if (!pullRequest.branch) {
-      continue;
-    }
-
-    const pullRequestKey = `${pullRequest.repository}::${pullRequest.branch}`;
-    if (!latestPullRequestByKey.has(pullRequestKey)) {
-      latestPullRequestByKey.set(pullRequestKey, pullRequest);
-    }
-  }
-
-  const groupedTasks: Record<TaskSidebarGroup, Array<(typeof tasks)[number]>> = {
-    merged: [],
-    needsAction: [],
-    openNoPr: [],
-    awaitingReview: [],
-    running: [],
-  };
-
-  for (const task of tasks) {
-    const projectRepository = extractOrgRepoFromUrl(
-      task.project_id ? projectsById.get(task.project_id)?.repo_url : null,
-    );
-    const pullRequest =
-      projectRepository && task.branch
-        ? (latestPullRequestByKey.get(`${projectRepository}::${task.branch}`) ?? null)
-        : null;
-    const pullRequestStatus = pullRequest ? getPullRequestStatus(pullRequest) : null;
-    const groupKey = getSidebarGroupKey({
-      taskStatus: task.status,
-      pullRequestStatus,
-      reviewState: pullRequest?.review_state,
-      checksConclusion: pullRequest?.checks_conclusion,
-      hasError: (task.error?.trim().length ?? 0) > 0,
-    });
-    groupedTasks[groupKey].push(task);
-  }
-
-  async function handleNewTask() {
-    const repoUrl = defaultProject?.repo_url;
-    if (creating || !defaultProject || !repoUrl) return;
-    setCreating(true);
-    try {
-      const title = "New task";
-      const response = await createDesktopRunnerSession(title, repoUrl);
-
-      const now = Date.now();
-      const task = {
-        id: crypto.randomUUID(),
-        organization_id: defaultProject.organization_id,
-        project_id: defaultProject.id,
-        title,
-        status: "open",
-        stream_id: null,
-        branch: null,
-        runner_type: response.runnerType,
-        runner_session_id: response.sessionId,
-        workspace_path: response.workspaceDirectory,
-        error: null,
-        created_at: BigInt(now),
-        updated_at: BigInt(now),
-      };
-
-      const tx = tasksCollection.insert(task);
-      navigate({ to: "/tasks/$taskId", params: { taskId: task.id } });
-      await tx.isPersisted.promise;
-    } finally {
-      setCreating(false);
-    }
-  }
+  const groupedTasks = buildTaskSidebarGroups({ tasks, projects, pullRequests });
 
   function handleDeleteDialogOpenChange(open: boolean) {
     if (deletingTask) {
@@ -243,25 +108,16 @@ export function TaskList() {
         <p className="text-[11px] font-bold text-foreground/90 uppercase tracking-[0.08em]">
           Tasks
         </p>
-        <Button
-          type="button"
+        <NewTaskButton
           variant="ghost"
           size="icon-xs"
-          onClick={handleNewTask}
-          disabled={creating || !defaultProject}
+          iconOnly
           className="text-muted-foreground shadow-none hover:border-transparent hover:shadow-none"
-          title="New task"
-        >
-          {creating ? (
-            <Loader2 className="w-3.5 h-3.5 animate-spin" />
-          ) : (
-            <Plus className="w-3.5 h-3.5" />
-          )}
-        </Button>
+        />
       </div>
 
       <nav className="neo-scroll flex-1 space-y-3 overflow-x-hidden overflow-y-auto px-2 pb-24 md:pb-2">
-        {SIDEBAR_GROUPS.map((group) => {
+        {TASK_SIDEBAR_GROUPS.map((group) => {
           const tasksInGroup = groupedTasks[group.key];
 
           return (

--- a/src/components/new-task-button.tsx
+++ b/src/components/new-task-button.tsx
@@ -1,0 +1,76 @@
+import { useState, type ComponentProps } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { useLiveQuery } from "@tanstack/react-db";
+import { Loader2, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { projectsCollection, tasksCollection } from "@/lib/collections";
+import { createDesktopRunnerSession } from "@/lib/desktop-runner";
+
+type ButtonProps = ComponentProps<typeof Button>;
+
+type NewTaskButtonProps = Omit<ButtonProps, "children" | "disabled" | "onClick"> & {
+  iconOnly?: boolean;
+};
+
+export function NewTaskButton({ iconOnly = false, title, ...props }: NewTaskButtonProps) {
+  const navigate = useNavigate();
+  const [creating, setCreating] = useState(false);
+  const { data: projects } = useLiveQuery((query) =>
+    query.from({ p: projectsCollection }).orderBy(({ p }) => p.created_at, "asc"),
+  );
+
+  const [defaultProject] = projects;
+
+  async function handleNewTask() {
+    const repoUrl = defaultProject?.repo_url;
+    if (creating || !defaultProject || !repoUrl) {
+      return;
+    }
+
+    setCreating(true);
+
+    try {
+      const taskTitle = "New task";
+      const response = await createDesktopRunnerSession(taskTitle, repoUrl);
+      const now = Date.now();
+      const taskId = crypto.randomUUID();
+      const tx = tasksCollection.insert({
+        id: taskId,
+        organization_id: defaultProject.organization_id,
+        project_id: defaultProject.id,
+        title: taskTitle,
+        status: "open",
+        stream_id: null,
+        branch: null,
+        runner_type: response.runnerType,
+        runner_session_id: response.sessionId,
+        workspace_path: response.workspaceDirectory,
+        error: null,
+        created_at: BigInt(now),
+        updated_at: BigInt(now),
+      });
+
+      navigate({ to: "/tasks/$taskId", params: { taskId } });
+      await tx.isPersisted.promise;
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      title={title ?? "New task"}
+      disabled={creating || !defaultProject}
+      onClick={() => void handleNewTask()}
+      {...props}
+    >
+      {creating ? (
+        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+      ) : (
+        <Plus className="w-3.5 h-3.5" />
+      )}
+      {iconOnly ? null : <span>New task</span>}
+    </Button>
+  );
+}

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -33,6 +33,7 @@ const taskSchema = z.object({
   created_at: z.bigint(),
   updated_at: z.bigint(),
 });
+export type Task = z.infer<typeof taskSchema>;
 
 const pullRequestSchema = z.object({
   id: z.string(),
@@ -51,6 +52,7 @@ const pullRequestSchema = z.object({
   checks_conclusion: z.string().nullable().optional(),
   checks_updated_at: z.bigint().nullable().optional(),
 });
+export type PullRequest = z.infer<typeof pullRequestSchema>;
 
 const taskMessageSchema = z.object({
   id: z.string(),

--- a/src/lib/task-sidebar.ts
+++ b/src/lib/task-sidebar.ts
@@ -1,0 +1,134 @@
+import type { Project, PullRequest, Task } from "@/lib/collections";
+import {
+  extractOrgRepoFromUrl,
+  getPullRequestStatus,
+  type PullRequestStatus,
+} from "@/lib/pull-request";
+
+export type TaskSidebarGroup = "merged" | "needsAction" | "openNoPr" | "awaitingReview" | "running";
+
+export const TASK_SIDEBAR_GROUPS: Array<{ key: TaskSidebarGroup; label: string }> = [
+  { key: "merged", label: "Merged" },
+  { key: "needsAction", label: "Needs action" },
+  { key: "openNoPr", label: "Open (no PR)" },
+  { key: "awaitingReview", label: "Awaiting review" },
+  { key: "running", label: "Running" },
+];
+
+const FAILING_CHECK_CONCLUSIONS = new Set([
+  "failure",
+  "cancelled",
+  "timed_out",
+  "action_required",
+  "startup_failure",
+  "stale",
+]);
+
+function hasFailingChecks(checksConclusion: string | null | undefined): boolean {
+  if (!checksConclusion) {
+    return false;
+  }
+
+  return FAILING_CHECK_CONCLUSIONS.has(checksConclusion);
+}
+
+function getSidebarGroupKey(params: {
+  checksConclusion: string | null | undefined;
+  hasError: boolean;
+  pullRequestStatus: PullRequestStatus | null;
+  reviewState: string | null | undefined;
+  taskStatus: string;
+}): TaskSidebarGroup {
+  const { checksConclusion, hasError, pullRequestStatus, reviewState, taskStatus } = params;
+
+  if (taskStatus === "running") {
+    return "running";
+  }
+
+  if (pullRequestStatus === "merged") {
+    return "merged";
+  }
+
+  if (
+    hasError ||
+    reviewState === "changes_requested" ||
+    hasFailingChecks(checksConclusion) ||
+    pullRequestStatus === "closed" ||
+    pullRequestStatus === "draft"
+  ) {
+    return "needsAction";
+  }
+
+  if (!pullRequestStatus) {
+    return "openNoPr";
+  }
+
+  return "awaitingReview";
+}
+
+export function buildTaskSidebarGroups(params: {
+  projects: Project[];
+  pullRequests: PullRequest[];
+  tasks: Task[];
+}): Record<TaskSidebarGroup, Task[]> {
+  const { projects, pullRequests, tasks } = params;
+  const projectsById = new Map(projects.map((project) => [project.id, project]));
+  const latestPullRequestByKey = new Map<string, PullRequest>();
+
+  for (const pullRequest of pullRequests) {
+    if (!pullRequest.branch) {
+      continue;
+    }
+
+    const pullRequestKey = `${pullRequest.repository}::${pullRequest.branch}`;
+    if (!latestPullRequestByKey.has(pullRequestKey)) {
+      latestPullRequestByKey.set(pullRequestKey, pullRequest);
+    }
+  }
+
+  const groupedTasks: Record<TaskSidebarGroup, Task[]> = {
+    merged: [],
+    needsAction: [],
+    openNoPr: [],
+    awaitingReview: [],
+    running: [],
+  };
+
+  for (const task of tasks) {
+    const projectRepository = extractOrgRepoFromUrl(
+      task.project_id ? projectsById.get(task.project_id)?.repo_url : null,
+    );
+    const pullRequest =
+      projectRepository && task.branch
+        ? (latestPullRequestByKey.get(`${projectRepository}::${task.branch}`) ?? null)
+        : null;
+    const pullRequestStatus = pullRequest ? getPullRequestStatus(pullRequest) : null;
+    const groupKey = getSidebarGroupKey({
+      taskStatus: task.status,
+      pullRequestStatus,
+      reviewState: pullRequest?.review_state,
+      checksConclusion: pullRequest?.checks_conclusion,
+      hasError: (task.error?.trim().length ?? 0) > 0,
+    });
+    groupedTasks[groupKey].push(task);
+  }
+
+  return groupedTasks;
+}
+
+export function getFirstSidebarTaskId(params: {
+  projects: Project[];
+  pullRequests: PullRequest[];
+  tasks: Task[];
+}): string | null {
+  const groupedTasks = buildTaskSidebarGroups(params);
+
+  for (const group of TASK_SIDEBAR_GROUPS) {
+    const firstTask = groupedTasks[group.key][0];
+    if (firstTask) {
+      return firstTask.id;
+    }
+  }
+
+  return null;
+}

--- a/src/pages/runner-home-page.tsx
+++ b/src/pages/runner-home-page.tsx
@@ -1,23 +1,37 @@
 import { useEffect } from "react";
+import { useLiveQuery } from "@tanstack/react-db";
 import { useNavigate } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
-import { useRunnerSessions } from "@/lib/runner-sessions";
+import { NewTaskButton } from "@/components/new-task-button";
+import { projectsCollection, pullRequestsCollection, tasksCollection } from "@/lib/collections";
+import { getFirstSidebarTaskId } from "@/lib/task-sidebar";
 
 export function RunnerHomePage() {
   const navigate = useNavigate();
-  const { error, isDesktopApp, isLoading, sessions } = useRunnerSessions();
+  const { data: tasks, isLoading: isTasksLoading } = useLiveQuery((query) =>
+    query.from({ t: tasksCollection }).orderBy(({ t }) => t.updated_at, "desc"),
+  );
+  const { data: projects } = useLiveQuery((query) =>
+    query.from({ p: projectsCollection }).orderBy(({ p }) => p.created_at, "asc"),
+  );
+  const { data: pullRequests, isLoading: isPullRequestsLoading } = useLiveQuery((query) =>
+    query.from({ pr: pullRequestsCollection }).orderBy(({ pr }) => pr.opened_at, "desc"),
+  );
+
+  const isLoading = isTasksLoading || isPullRequestsLoading;
+  const firstTaskId = getFirstSidebarTaskId({ tasks, projects, pullRequests });
 
   useEffect(() => {
-    if (isLoading || sessions.length === 0) {
+    if (isLoading || !firstTaskId) {
       return;
     }
 
     navigate({
-      to: "/runner/$sessionId",
-      params: { sessionId: sessions[0].id },
+      to: "/tasks/$taskId",
+      params: { taskId: firstTaskId },
       replace: true,
     });
-  }, [isLoading, navigate, sessions]);
+  }, [firstTaskId, isLoading, navigate]);
 
   if (isLoading) {
     return (
@@ -27,16 +41,18 @@ export function RunnerHomePage() {
     );
   }
 
+  if (firstTaskId) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin" />
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-full items-center justify-center px-4">
-      <div className="neo-surface max-w-lg rounded-[var(--radius-md)] p-6 text-center">
-        <p className="text-base font-semibold text-foreground">
-          {isDesktopApp ? "Start a session from the sidebar" : "Runner sessions are desktop-only"}
-        </p>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {error ??
-            "The current runner flow is intentionally minimal: pick or create a session in the sidebar to continue."}
-        </p>
+      <div className="neo-surface rounded-[var(--radius-md)] p-6 text-center">
+        <NewTaskButton size="default" />
       </div>
     </div>
   );

--- a/src/pages/runner-session-page.tsx
+++ b/src/pages/runner-session-page.tsx
@@ -33,8 +33,7 @@ export function RunnerSessionPage({ sessionId }: { sessionId: string }) {
             {session.title}
           </h1>
           <p className="mt-2 text-sm text-muted-foreground">
-            This route is intentionally basic. It proves the desktop app can list and create local
-            runner sessions without going through the existing task backend flow.
+            This session is ready in the local runner workspace shown below.
           </p>
         </section>
 


### PR DESCRIPTION
## Summary
- open the first task in the existing sidebar order when the app lands on `/runner`
- replace the runner empty state copy with a single `New task` action when there are no tasks yet
- reuse shared sidebar grouping and task creation logic so the landing page and sidebar stay in sync

## Verification
- `bun run format`
- `bun run lint:fix`
- `bun run build` *(fails: Cannot find package `vite` imported from `vite.config.ts` in this workspace)*
- `bun run knip` *(fails: Cannot find module `drizzle-kit` while loading `drizzle.config.ts` in this workspace)*