### PR TITLE
feat(pr): show total check progress

### DIFF
--- a/drizzle/0003_known_ben_parker.sql
+++ b/drizzle/0003_known_ben_parker.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "pull_requests" ADD COLUMN "checks_count" integer;--> statement-breakpoint
+ALTER TABLE "pull_requests" ADD COLUMN "checks_completed_count" integer;--> statement-breakpoint
+CREATE TABLE "pull_request_check_runs" (
+	"id" text PRIMARY KEY NOT NULL,
+	"repository" text NOT NULL,
+	"pr_number" integer NOT NULL,
+	"check_run_id" text NOT NULL,
+	"status" text NOT NULL,
+	"conclusion" text,
+	"updated_at" bigint NOT NULL
+);--> statement-breakpoint
+CREATE UNIQUE INDEX "pr_check_run_unique" ON "pull_request_check_runs" USING btree ("repository","pr_number","check_run_id");--> statement-breakpoint
+CREATE INDEX "pr_check_run_lookup" ON "pull_request_check_runs" USING btree ("repository","pr_number");

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -47,6 +47,8 @@ const pullRequestSchema = z.object({
   state: z.string().optional(),
   review_state: z.string().nullable().optional(),
   review_updated_at: z.bigint().nullable().optional(),
+  checks_count: z.number().nullable().optional(),
+  checks_completed_count: z.number().nullable().optional(),
   checks_state: z.string().nullable().optional(),
   checks_conclusion: z.string().nullable().optional(),
   checks_updated_at: z.bigint().nullable().optional(),

--- a/src/pages/task-page.tsx
+++ b/src/pages/task-page.tsx
@@ -79,6 +79,8 @@ interface TaskPageProps {
     url: string;
     status: "open" | "merged" | "closed" | "draft";
     reviewState: string | null;
+    checksCount: number | null;
+    checksCompletedCount: number | null;
     checksState: string | null;
     checksConclusion: string | null;
   } | null;
@@ -158,6 +160,26 @@ function formatChecksStatus(checksState: string | null, checksConclusion: string
   }
 
   return humanizePullRequestStatus(checksState ?? checksConclusion);
+}
+
+function formatChecksProgress(
+  checksCompletedCount: number | null,
+  checksCount: number | null,
+  checksState: string | null,
+  checksConclusion: string | null,
+): string {
+  if (checksCount != null && checksCount > 0) {
+    const completedChecks = Math.min(checksCompletedCount ?? 0, checksCount);
+    const pendingChecks = Math.max(0, checksCount - completedChecks);
+
+    if (pendingChecks > 0) {
+      return `${completedChecks}/${checksCount} checks done, ${pendingChecks} pending`;
+    }
+
+    return `${completedChecks}/${checksCount} checks done`;
+  }
+
+  return formatChecksStatus(checksState, checksConclusion);
 }
 
 export function TaskPage({
@@ -431,7 +453,9 @@ export function TaskPage({
                       Review: {humanizePullRequestStatus(pullRequest.reviewState)}
                     </span>
                   ) : null}
-                  {pullRequest.checksState != null || pullRequest.checksConclusion != null ? (
+                  {pullRequest.checksState != null ||
+                  pullRequest.checksConclusion != null ||
+                  pullRequest.checksCount != null ? (
                     <span
                       className={cn(
                         "rounded border px-2 py-0.5 text-[11px] font-medium",
@@ -442,7 +466,12 @@ export function TaskPage({
                       )}
                     >
                       Checks:{" "}
-                      {formatChecksStatus(pullRequest.checksState, pullRequest.checksConclusion)}
+                      {formatChecksProgress(
+                        pullRequest.checksCompletedCount,
+                        pullRequest.checksCount,
+                        pullRequest.checksState,
+                        pullRequest.checksConclusion,
+                      )}
                     </span>
                   ) : null}
                 </div>

--- a/src/routes/_layout.tasks.$taskId.tsx
+++ b/src/routes/_layout.tasks.$taskId.tsx
@@ -77,6 +77,8 @@ export const Route = createFileRoute("/_layout/tasks/$taskId")({
                 url: `https://github.com/${pullRequest.repository}/pull/${pullRequest.pr_number}`,
                 status: getPullRequestStatus(pullRequest),
                 reviewState: pullRequest.review_state ?? null,
+                checksCount: pullRequest.checks_count ?? null,
+                checksCompletedCount: pullRequest.checks_completed_count ?? null,
                 checksState: pullRequest.checks_state ?? null,
                 checksConclusion: pullRequest.checks_conclusion ?? null,
               }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -189,6 +189,8 @@ export const pullRequests = pgTable(
     state: text("state").notNull().default("open"),
     reviewState: text("review_state"),
     reviewUpdatedAt: msTimestamp("review_updated_at"),
+    checksCount: integer("checks_count"),
+    checksCompletedCount: integer("checks_completed_count"),
     checksState: text("checks_state"),
     checksConclusion: text("checks_conclusion"),
     checksUpdatedAt: msTimestamp("checks_updated_at"),
@@ -196,6 +198,23 @@ export const pullRequests = pgTable(
   (t) => [
     uniqueIndex("pr_repo_number").on(t.repository, t.prNumber),
     index("pr_installation").on(t.installationId),
+  ],
+);
+
+export const pullRequestCheckRuns = pgTable(
+  "pull_request_check_runs",
+  {
+    id: text("id").primaryKey(),
+    repository: text("repository").notNull(),
+    prNumber: integer("pr_number").notNull(),
+    checkRunId: text("check_run_id").notNull(),
+    status: text("status").notNull(),
+    conclusion: text("conclusion"),
+    updatedAt: msTimestamp("updated_at").notNull(),
+  },
+  (t) => [
+    uniqueIndex("pr_check_run_unique").on(t.repository, t.prNumber, t.checkRunId),
+    index("pr_check_run_lookup").on(t.repository, t.prNumber),
   ],
 );
 

--- a/src/server/webhook/github/check-run.ts
+++ b/src/server/webhook/github/check-run.ts
@@ -1,7 +1,7 @@
 import type { EmitterWebhookEvent } from "@octokit/webhooks";
-import { and, eq, inArray } from "drizzle-orm";
 import type { AppDb } from "../../db/client";
 import { pullRequests } from "../../db/schema";
+import { upsertPullRequestCheckRunCounts } from "./pull-request-check-runs";
 
 export async function handleCheckRun(
   event: EmitterWebhookEvent<"check_run">,
@@ -46,19 +46,12 @@ export async function handleCheckRun(
       target: [pullRequests.repository, pullRequests.prNumber],
     });
 
-  if (checkRun.status !== "completed") {
-    await db
-      .update(pullRequests)
-      .set({
-        checksState: checkRun.status,
-        checksConclusion: checkRun.conclusion,
-        checksUpdatedAt: now,
-      })
-      .where(
-        and(
-          eq(pullRequests.repository, repository.full_name),
-          inArray(pullRequests.prNumber, prNumbers),
-        ),
-      );
-  }
+  await upsertPullRequestCheckRunCounts({
+    db,
+    repository: repository.full_name,
+    prNumbers,
+    checkRunId: checkRun.id,
+    conclusion: checkRun.conclusion,
+    status: checkRun.status,
+  });
 }

--- a/src/server/webhook/github/check-suite.ts
+++ b/src/server/webhook/github/check-suite.ts
@@ -2,6 +2,7 @@ import type { EmitterWebhookEvent } from "@octokit/webhooks";
 import { and, eq, inArray } from "drizzle-orm";
 import type { AppDb } from "../../db/client";
 import { pullRequests } from "../../db/schema";
+import { resetPullRequestCheckRuns } from "./pull-request-check-runs";
 
 export async function handleCheckSuite(
   event: EmitterWebhookEvent<"check_suite">,
@@ -31,6 +32,14 @@ export async function handleCheckSuite(
   console.log(`PR checks updated via check_suite (${action}) for ${repository.full_name}`);
 
   const now = Date.now();
+  if (action === "requested" || action === "rerequested") {
+    await resetPullRequestCheckRuns({
+      db,
+      repository: repository.full_name,
+      prNumbers,
+    });
+  }
+
   await db
     .insert(pullRequests)
     .values(
@@ -51,6 +60,13 @@ export async function handleCheckSuite(
     .update(pullRequests)
     .set({
       branch: checkSuite.head_branch ?? undefined,
+      checksCount: checkSuite.latest_check_runs_count,
+      checksCompletedCount:
+        action === "completed" && checkSuite.latest_check_runs_count != null
+          ? checkSuite.latest_check_runs_count
+          : action === "requested" || action === "rerequested"
+            ? null
+            : undefined,
       checksState: checkSuite.status,
       checksConclusion: checkSuite.conclusion,
       checksUpdatedAt: now,

--- a/src/server/webhook/github/pull-request-check-runs.ts
+++ b/src/server/webhook/github/pull-request-check-runs.ts
@@ -1,0 +1,133 @@
+import { and, eq, inArray } from "drizzle-orm";
+import type { AppDb } from "../../db/client";
+import { pullRequestCheckRuns, pullRequests } from "../../db/schema";
+
+interface ResetPullRequestCheckRunsParams {
+  db: AppDb;
+  repository: string;
+  prNumbers: number[];
+}
+
+interface UpsertPullRequestCheckRunParams extends ResetPullRequestCheckRunsParams {
+  checkRunId: number;
+  conclusion: string | null;
+  status: string;
+}
+
+export async function resetPullRequestCheckRuns({
+  db,
+  repository,
+  prNumbers,
+}: ResetPullRequestCheckRunsParams): Promise<void> {
+  if (prNumbers.length === 0) {
+    return;
+  }
+
+  await db
+    .delete(pullRequestCheckRuns)
+    .where(
+      and(
+        eq(pullRequestCheckRuns.repository, repository),
+        inArray(pullRequestCheckRuns.prNumber, prNumbers),
+      ),
+    );
+}
+
+export async function upsertPullRequestCheckRunCounts({
+  db,
+  repository,
+  prNumbers,
+  checkRunId,
+  conclusion,
+  status,
+}: UpsertPullRequestCheckRunParams): Promise<void> {
+  if (prNumbers.length === 0) {
+    return;
+  }
+
+  const now = Date.now();
+  const checkRunIdText = String(checkRunId);
+
+  await db
+    .insert(pullRequestCheckRuns)
+    .values(
+      prNumbers.map((prNumber) => ({
+        id: `${repository}:${prNumber}:${checkRunIdText}`,
+        repository,
+        prNumber,
+        checkRunId: checkRunIdText,
+        status,
+        conclusion,
+        updatedAt: now,
+      })),
+    )
+    .onConflictDoUpdate({
+      target: [
+        pullRequestCheckRuns.repository,
+        pullRequestCheckRuns.prNumber,
+        pullRequestCheckRuns.checkRunId,
+      ],
+      set: {
+        status,
+        conclusion,
+        updatedAt: now,
+      },
+    });
+
+  const [checkRunRows, pullRequestRows] = await Promise.all([
+    db
+      .select({
+        prNumber: pullRequestCheckRuns.prNumber,
+        status: pullRequestCheckRuns.status,
+      })
+      .from(pullRequestCheckRuns)
+      .where(
+        and(
+          eq(pullRequestCheckRuns.repository, repository),
+          inArray(pullRequestCheckRuns.prNumber, prNumbers),
+        ),
+      ),
+    db
+      .select({
+        prNumber: pullRequests.prNumber,
+        checksCount: pullRequests.checksCount,
+      })
+      .from(pullRequests)
+      .where(
+        and(eq(pullRequests.repository, repository), inArray(pullRequests.prNumber, prNumbers)),
+      ),
+  ]);
+
+  const countsByPrNumber = new Map<number, { completed: number; total: number }>();
+  for (const row of checkRunRows) {
+    const current = countsByPrNumber.get(row.prNumber) ?? { completed: 0, total: 0 };
+    current.total += 1;
+    if (row.status === "completed") {
+      current.completed += 1;
+    }
+    countsByPrNumber.set(row.prNumber, current);
+  }
+
+  await Promise.all(
+    pullRequestRows.map((pullRequestRow) => {
+      const counts = countsByPrNumber.get(pullRequestRow.prNumber) ?? { completed: 0, total: 0 };
+      const totalChecks = Math.max(pullRequestRow.checksCount ?? 0, counts.total);
+
+      return db
+        .update(pullRequests)
+        .set({
+          checksCompletedCount: counts.completed,
+          checksCount: totalChecks > 0 ? totalChecks : null,
+          checksConclusion: status === "completed" ? undefined : conclusion,
+          checksState: status === "completed" ? undefined : status,
+          checksUpdatedAt: now,
+        })
+        .where(
+          and(
+            eq(pullRequests.repository, repository),
+            eq(pullRequests.prNumber, pullRequestRow.prNumber),
+          ),
+        );
+    }),
+  );
+}

--- a/src/server/webhook/github/pull-request.ts
+++ b/src/server/webhook/github/pull-request.ts
@@ -2,6 +2,7 @@ import type { EmitterWebhookEvent } from "@octokit/webhooks";
 import { and, eq, isNull, lte, or } from "drizzle-orm";
 import type { AppDb } from "../../db/client";
 import { pullRequests } from "../../db/schema";
+import { resetPullRequestCheckRuns } from "./pull-request-check-runs";
 
 export async function handlePullRequest(
   event: EmitterWebhookEvent<"pull_request">,
@@ -73,11 +74,18 @@ export async function handlePullRequest(
             mergedBy: null,
             reviewState: null,
             reviewUpdatedAt: null,
+            checksCount: null,
+            checksCompletedCount: null,
             checksState: null,
             checksConclusion: null,
             checksUpdatedAt: null,
           },
         });
+      await resetPullRequestCheckRuns({
+        db,
+        repository: repository.full_name,
+        prNumbers: [pr.number],
+      });
       break;
     }
 
@@ -119,6 +127,8 @@ export async function handlePullRequest(
       await db
         .update(pullRequests)
         .set({
+          checksCount: null,
+          checksCompletedCount: null,
           checksState: null,
           checksConclusion: null,
           checksUpdatedAt: pullRequestEventAt,
@@ -132,6 +142,11 @@ export async function handlePullRequest(
             ),
           ),
         );
+      await resetPullRequestCheckRuns({
+        db,
+        repository: repository.full_name,
+        prNumbers: [pr.number],
+      });
       break;
     }
 
@@ -147,11 +162,18 @@ export async function handlePullRequest(
           mergedBy: null,
           reviewState: null,
           reviewUpdatedAt: Date.now(),
+          checksCount: null,
+          checksCompletedCount: null,
           checksState: null,
           checksConclusion: null,
           checksUpdatedAt: Date.now(),
         })
         .where(pullRequestWhere);
+      await resetPullRequestCheckRuns({
+        db,
+        repository: repository.full_name,
+        prNumbers: [pr.number],
+      });
       break;
     }
 
@@ -167,11 +189,18 @@ export async function handlePullRequest(
           state: pr.draft ? "draft" : "open",
           reviewState: null,
           reviewUpdatedAt: Date.now(),
+          checksCount: null,
+          checksCompletedCount: null,
           checksState: null,
           checksConclusion: null,
           checksUpdatedAt: Date.now(),
         })
         .where(pullRequestWhere);
+      await resetPullRequestCheckRuns({
+        db,
+        repository: repository.full_name,
+        prNumbers: [pr.number],
+      });
       break;
     }
 


### PR DESCRIPTION
## Summary
- show completed and total GitHub check counts in the PR details badge so task pages can display progress like `1/7 checks done, 6 pending`
- persist pull request check totals and completed counts, including a migration for the new fields and per-check-run tracking table
- update GitHub check webhook handling to keep counts in sync when suites are requested, rerun, completed, or when a PR sync resets checks