### PR TITLE
feat: add new task keyboard shortcut

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/electric-db-collection": "^0.2.33",
         "@tanstack/react-db": "0.1.70",
+        "@tanstack/react-hotkeys": "^0.3.2",
         "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-router": "^1.162.8",
         "@tanstack/react-start": "^1.162.8",
@@ -704,11 +705,15 @@
 
     "@tanstack/history": ["@tanstack/history@1.161.4", "", {}, "sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww=="],
 
+    "@tanstack/hotkeys": ["@tanstack/hotkeys@0.3.2", "", { "dependencies": { "@tanstack/store": "^0.9.1" } }, "sha512-+ihZ/aaD2kvKLasLMdKL9bPASMruJhfVT052deIBMSVb5yuB1x82MpPuGsaKJy6A74fGOdmlxLcARBKXG1ZIaQ=="],
+
     "@tanstack/pacer-lite": ["@tanstack/pacer-lite@0.2.1", "", {}, "sha512-3PouiFjR4B6x1c969/Pl4ZIJleof1M0n6fNX8NRiC9Sqv1g06CVDlEaXUR4212ycGFyfq4q+t8Gi37Xy+z34iQ=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.90.20", "", {}, "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg=="],
 
     "@tanstack/react-db": ["@tanstack/react-db@0.1.70", "", { "dependencies": { "@tanstack/db": "0.5.26", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-OISznZtrjkbyktbAoj/2KyFf9Xv9vr7JfkQO4od4eH76X+vQXYZkVgs2IV5sM27YNatOyf1Or4BEELIbyYB4xA=="],
+
+    "@tanstack/react-hotkeys": ["@tanstack/react-hotkeys@0.3.2", "", { "dependencies": { "@tanstack/hotkeys": "0.3.2", "@tanstack/react-store": "^0.9.1" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-tSYs4N65I87coXO6D4D24QkWdrQVsldRBxpPubr+gE7P1bU+a8j8B1Lv379j+TcCtpK1IzgJ88SCkqS9dyf49g=="],
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
 
@@ -1883,6 +1888,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@tanstack/hotkeys/@tanstack/store": ["@tanstack/store@0.9.1", "", {}, "sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg=="],
 
     "@tanstack/react-store/@tanstack/store": ["@tanstack/store@0.9.1", "", {}, "sha512-+qcNkOy0N1qSGsP7omVCW0SDrXtaDcycPqBDE726yryiA5eTDFpjBReaYjghVJwNf1pcPMyzIwTGlYjCSQR0Fg=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/electric-db-collection": "^0.2.33",
     "@tanstack/react-db": "0.1.70",
+    "@tanstack/react-hotkeys": "^0.3.2",
     "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-router": "^1.162.8",
     "@tanstack/react-start": "^1.162.8",

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { Loader2 } from "lucide-react";
 import { AppQueryProvider } from "@/components/app-query-provider";
+import { NewTaskHotkey } from "@/components/new-task-hotkey";
 import { RunnerSessionsProvider } from "@/lib/runner-sessions";
 import { cn } from "../lib/utils";
 import { useSession } from "../lib/auth-client";
@@ -38,6 +39,7 @@ export function Layout() {
   return (
     <AppQueryProvider>
       <RunnerSessionsProvider>
+        <NewTaskHotkey />
         <div className="neo-enter flex h-dvh bg-background text-foreground">
           <div
             className={cn(

--- a/src/components/new-task-button.tsx
+++ b/src/components/new-task-button.tsx
@@ -1,10 +1,7 @@
-import { useState, type ComponentProps } from "react";
-import { useNavigate } from "@tanstack/react-router";
-import { useLiveQuery } from "@tanstack/react-db";
+import type { ComponentProps } from "react";
 import { Loader2, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { projectsCollection, tasksCollection } from "@/lib/collections";
-import { createDesktopRunnerSession } from "@/lib/desktop-runner";
+import { useCreateNewTask } from "@/lib/use-create-new-task";
 
 type ButtonProps = ComponentProps<typeof Button>;
 
@@ -13,56 +10,14 @@ type NewTaskButtonProps = Omit<ButtonProps, "children" | "disabled" | "onClick">
 };
 
 export function NewTaskButton({ iconOnly = false, title, ...props }: NewTaskButtonProps) {
-  const navigate = useNavigate();
-  const [creating, setCreating] = useState(false);
-  const { data: projects } = useLiveQuery((query) =>
-    query.from({ p: projectsCollection }).orderBy(({ p }) => p.created_at, "asc"),
-  );
-
-  const [defaultProject] = projects;
-
-  async function handleNewTask() {
-    const repoUrl = defaultProject?.repo_url;
-    if (creating || !defaultProject || !repoUrl) {
-      return;
-    }
-
-    setCreating(true);
-
-    try {
-      const taskTitle = "New task";
-      const response = await createDesktopRunnerSession(taskTitle, repoUrl);
-      const now = Date.now();
-      const taskId = crypto.randomUUID();
-      const tx = tasksCollection.insert({
-        id: taskId,
-        organization_id: defaultProject.organization_id,
-        project_id: defaultProject.id,
-        title: taskTitle,
-        status: "open",
-        stream_id: null,
-        branch: null,
-        runner_type: response.runnerType,
-        runner_session_id: response.sessionId,
-        workspace_path: response.workspaceDirectory,
-        error: null,
-        created_at: BigInt(now),
-        updated_at: BigInt(now),
-      });
-
-      navigate({ to: "/tasks/$taskId", params: { taskId } });
-      await tx.isPersisted.promise;
-    } finally {
-      setCreating(false);
-    }
-  }
+  const { canCreateTask, createNewTask, creating } = useCreateNewTask();
 
   return (
     <Button
       type="button"
-      title={title ?? "New task"}
-      disabled={creating || !defaultProject}
-      onClick={() => void handleNewTask()}
+      title={title ?? "New task (Cmd/Ctrl+N)"}
+      disabled={!canCreateTask}
+      onClick={() => void createNewTask()}
       {...props}
     >
       {creating ? (

--- a/src/components/new-task-hotkey.tsx
+++ b/src/components/new-task-hotkey.tsx
@@ -1,0 +1,19 @@
+import { useHotkey } from "@tanstack/react-hotkeys";
+import { NEW_TASK_HOTKEY, useCreateNewTask } from "@/lib/use-create-new-task";
+
+export function NewTaskHotkey() {
+  const { canCreateTask, createNewTask } = useCreateNewTask();
+
+  useHotkey(
+    NEW_TASK_HOTKEY,
+    () => {
+      void createNewTask();
+    },
+    {
+      enabled: canCreateTask,
+      requireReset: true,
+    },
+  );
+
+  return null;
+}

--- a/src/lib/use-create-new-task.ts
+++ b/src/lib/use-create-new-task.ts
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { useLiveQuery } from "@tanstack/react-db";
+import { useNavigate } from "@tanstack/react-router";
+import { projectsCollection, tasksCollection } from "@/lib/collections";
+import { createDesktopRunnerSession } from "@/lib/desktop-runner";
+
+export const NEW_TASK_HOTKEY = "Mod+N";
+
+export function useCreateNewTask() {
+  const navigate = useNavigate();
+  const [creating, setCreating] = useState(false);
+  const { data: projects } = useLiveQuery((query) =>
+    query.from({ p: projectsCollection }).orderBy(({ p }) => p.created_at, "asc"),
+  );
+
+  const [defaultProject] = projects;
+  const canCreateTask = !creating && Boolean(defaultProject?.repo_url);
+
+  async function createNewTask() {
+    const repoUrl = defaultProject?.repo_url;
+    if (creating || !defaultProject || !repoUrl) {
+      return;
+    }
+
+    setCreating(true);
+
+    try {
+      const taskTitle = "New task";
+      const response = await createDesktopRunnerSession(taskTitle, repoUrl);
+      const now = Date.now();
+      const taskId = crypto.randomUUID();
+      const tx = tasksCollection.insert({
+        id: taskId,
+        organization_id: defaultProject.organization_id,
+        project_id: defaultProject.id,
+        title: taskTitle,
+        status: "open",
+        stream_id: null,
+        branch: null,
+        runner_type: response.runnerType,
+        runner_session_id: response.sessionId,
+        workspace_path: response.workspaceDirectory,
+        error: null,
+        created_at: BigInt(now),
+        updated_at: BigInt(now),
+      });
+
+      navigate({ to: "/tasks/$taskId", params: { taskId } });
+      await tx.isPersisted.promise;
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return {
+    canCreateTask,
+    createNewTask,
+    creating,
+  };
+}


### PR DESCRIPTION
## Summary
- add TanStack Hotkeys and register a global `Cmd/Ctrl+N` shortcut for creating a new task
- extract the new task creation flow into a shared hook so the hotkey and button stay in sync
- keep the existing button behavior while surfacing the shortcut in the button tooltip

## Testing
- bun run format
- bun run lint:fix
- bun run knip
- bun run build