### PR TITLE
feat(ui): add persisted dark mode

### DIFF
--- a/src/components/layout/user-menu.tsx
+++ b/src/components/layout/user-menu.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from "@tanstack/react-router";
 import { ChevronDown, LogOut, Settings } from "lucide-react";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -75,6 +76,8 @@ export function UserMenu({ showIdentity = false, menuDirection = "down" }: UserM
               Settings
             </Link>
           </DropdownMenuItem>
+
+          <ThemeToggle variant="menu-item" />
 
           <DropdownMenuItem
             onSelect={() =>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { localStorageKeys } from "@/lib/session-state";
+import { applyTheme, defaultTheme, getStoredTheme, type Theme } from "@/lib/theme";
+
+type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(defaultTheme);
+
+  useEffect(() => {
+    setThemeState(getStoredTheme());
+  }, []);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const setTheme = (nextTheme: Theme) => {
+    setThemeState(nextTheme);
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(localStorageKeys.theme().storageKey, nextTheme);
+    } catch {
+      return;
+    }
+  };
+
+  const toggleTheme = () => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (context === null) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+
+  return context;
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,38 @@
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "@/components/theme-provider";
+import { Button } from "@/components/ui/button";
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+type ThemeToggleProps = {
+  variant?: "button" | "menu-item";
+  className?: string;
+};
+
+export function ThemeToggle({ variant = "button", className }: ThemeToggleProps) {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === "dark";
+  const Icon = isDark ? Sun : Moon;
+  const label = isDark ? "Light mode" : "Dark mode";
+
+  if (variant === "menu-item") {
+    return (
+      <DropdownMenuItem onSelect={toggleTheme} className={className}>
+        <Icon className="h-4 w-4" />
+        {label}
+      </DropdownMenuItem>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={toggleTheme}
+      className={cn("justify-start", className)}
+    >
+      <Icon className="h-4 w-4" />
+      {label}
+    </Button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -51,27 +51,35 @@
   --border: #2b4b69;
   --input: #ffffff;
   --ring: #1f6fdb;
+  --body-glow-primary: rgb(31 111 219 / 20%);
+  --body-glow-secondary: rgb(217 74 74 / 11%);
+  --body-glow-tertiary: rgb(121 141 164 / 24%);
+  --body-grid: rgb(17 35 58 / 5%);
 }
 
 .dark {
-  --background: #eaf1f8;
-  --foreground: #0f2238;
-  --card: #f8fbff;
-  --card-foreground: #0f2238;
-  --popover: #f8fbff;
-  --popover-foreground: #0f2238;
-  --primary: #1f6fdb;
-  --primary-foreground: #f8fbff;
-  --secondary: #b8c7d8;
-  --secondary-foreground: #10263d;
-  --muted: #d7e0ea;
-  --muted-foreground: #4b6078;
-  --accent: #7fa4d1;
-  --accent-foreground: #0f2238;
-  --destructive: #d94a4a;
-  --border: #2b4b69;
-  --input: #ffffff;
-  --ring: #1f6fdb;
+  --background: #101924;
+  --foreground: #edf4ff;
+  --card: #172332;
+  --card-foreground: #edf4ff;
+  --popover: #172332;
+  --popover-foreground: #edf4ff;
+  --primary: #7db7ff;
+  --primary-foreground: #0c1621;
+  --secondary: #2a3f56;
+  --secondary-foreground: #edf4ff;
+  --muted: #203043;
+  --muted-foreground: #a0b4ca;
+  --accent: #314d6b;
+  --accent-foreground: #edf4ff;
+  --destructive: #ff7b7b;
+  --border: #5f7f9e;
+  --input: #122030;
+  --ring: #7db7ff;
+  --body-glow-primary: rgb(86 153 255 / 20%);
+  --body-glow-secondary: rgb(79 210 194 / 14%);
+  --body-glow-tertiary: rgb(9 13 20 / 38%);
+  --body-grid: rgb(237 244 255 / 4%);
 }
 
 html,
@@ -85,10 +93,10 @@ body {
   font-family: "Space Grotesk", "Segoe UI", sans-serif;
   letter-spacing: 0.01em;
   background:
-    radial-gradient(circle at 12% 22%, rgb(31 111 219 / 20%) 0%, transparent 24%),
-    radial-gradient(circle at 88% 8%, rgb(217 74 74 / 11%) 0%, transparent 16%),
-    radial-gradient(circle at 80% 68%, rgb(121 141 164 / 24%) 0%, transparent 24%),
-    repeating-linear-gradient(-12deg, rgb(17 35 58 / 5%) 0 2px, transparent 2px 28px),
+    radial-gradient(circle at 12% 22%, var(--body-glow-primary) 0%, transparent 24%),
+    radial-gradient(circle at 88% 8%, var(--body-glow-secondary) 0%, transparent 16%),
+    radial-gradient(circle at 80% 68%, var(--body-glow-tertiary) 0%, transparent 24%),
+    repeating-linear-gradient(-12deg, var(--body-grid) 0 2px, transparent 2px 28px),
     var(--background);
 }
 

--- a/src/lib/session-state.ts
+++ b/src/lib/session-state.ts
@@ -138,4 +138,9 @@ export const localStorageKeys = {
       "local",
       "last-used-task-model",
     ),
+  theme: () =>
+    createStorageStateKey<"light" | "dark">("local", "theme", {
+      parse: (value) => (value === "dark" ? "dark" : "light"),
+      serialize: (value) => value,
+    }),
 };

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,50 @@
+import { localStorageKeys } from "@/lib/session-state";
+
+export type Theme = "light" | "dark";
+
+export const defaultTheme: Theme = "light";
+
+const themeColors: Record<Theme, string> = {
+  light: "#eaf1f8",
+  dark: "#101924",
+};
+
+const themeStorageKey = localStorageKeys.theme().storageKey;
+
+function resolveTheme(value: unknown): Theme {
+  return value === "dark" ? "dark" : defaultTheme;
+}
+
+export function applyTheme(theme: Theme) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const root = document.documentElement;
+  root.classList.toggle("dark", theme === "dark");
+  root.style.colorScheme = theme;
+
+  const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+
+  if (themeColorMeta instanceof HTMLMetaElement) {
+    themeColorMeta.content = themeColors[theme];
+  }
+}
+
+export function getStoredTheme(): Theme {
+  if (typeof window === "undefined") {
+    return defaultTheme;
+  }
+
+  try {
+    return resolveTheme(window.localStorage.getItem(themeStorageKey));
+  } catch {
+    return defaultTheme;
+  }
+}
+
+export const themeInitializationScript = `(function(){try{var theme=localStorage.getItem(${JSON.stringify(
+  themeStorageKey,
+)});var resolved=theme==="dark"?"dark":"light";var root=document.documentElement;root.classList.toggle("dark",resolved==="dark");root.style.colorScheme=resolved;var meta=document.querySelector('meta[name="theme-color"]');if(meta){meta.setAttribute("content",resolved==="dark"?${JSON.stringify(
+  themeColors.dark,
+)}:${JSON.stringify(themeColors.light)})}}catch(_error){document.documentElement.style.colorScheme="light";}})();`;

--- a/src/pages/settings-page.tsx
+++ b/src/pages/settings-page.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { useLiveQuery } from "@tanstack/react-db";
 import { BookMarked, Loader2, Plus } from "lucide-react";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { AddProjectDialog } from "../components/add-project-dialog";
 import { useOrganization } from "../components/layout/use-organization";
@@ -148,6 +149,20 @@ export function SettingsPage() {
       <h2 className="mb-6 text-2xl tracking-[0.08em] uppercase">Settings</h2>
 
       <div className="neo-stagger space-y-6">
+        <section>
+          <Card>
+            <CardHeader className="gap-3 md:flex md:flex-row md:items-center md:justify-between">
+              <div className="space-y-1">
+                <CardTitle>Appearance</CardTitle>
+                <CardDescription>
+                  Switch the interface between the default light theme and a new dark mode.
+                </CardDescription>
+              </div>
+              <ThemeToggle className="w-full md:w-auto" />
+            </CardHeader>
+          </Card>
+        </section>
+
         <section>
           <div className="mb-4 flex items-center justify-between">
             <h3 className="text-sm font-bold tracking-[0.1em] text-foreground uppercase">

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,8 @@
 /// <reference types="vite/client" />
 import { HeadContent, Outlet, Scripts, createRootRoute } from "@tanstack/react-router";
 import type { ReactNode } from "react";
+import { ThemeProvider } from "@/components/theme-provider";
+import { themeInitializationScript } from "@/lib/theme";
 import appCss from "@/index.css?url";
 
 export const Route = createRootRoute({
@@ -22,13 +24,16 @@ export const Route = createRootRoute({
 
 function RootDocument({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
+        <script dangerouslySetInnerHTML={{ __html: themeInitializationScript }} />
       </head>
       <body>
-        {children}
-        <Scripts />
+        <ThemeProvider>
+          {children}
+          <Scripts />
+        </ThemeProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- add a persisted light/dark theme system that applies before hydration and updates the browser theme color
- add a reusable dark mode toggle in settings and the user menu so the preference is easy to change
- define a dark neobrutalist palette and atmospheric background tokens so existing surfaces adapt automatically

## Verification
- bun run format
- bun run lint:fix
- bun run knip *(fails: `drizzle-kit` is not installed in the current workspace)*
- bun run build *(fails: `vite` is not installed in the current workspace)*