### PR TITLE
fix: remove unused Conductor output copy

### DIFF
--- a/scripts/setup-conductor-worktree.sh
+++ b/scripts/setup-conductor-worktree.sh
@@ -4,18 +4,6 @@ set -eu
 
 ROOT_PATH="${CONDUCTOR_ROOT_PATH:?CONDUCTOR_ROOT_PATH is required}"
 
-copy_dir() {
-  src="$1"
-  dest="$2"
-
-  if [ ! -d "$src" ]; then
-    return
-  fi
-
-  mkdir -p "$(dirname "$dest")" "$dest"
-  rsync -a --delete "$src"/ "$dest"/
-}
-
 copy_file() {
   src="$1"
   dest="$2"
@@ -27,14 +15,3 @@ copy_file() {
 bun install
 mkdir -p dist
 copy_file "$ROOT_PATH/.env" ".env"
-
-if [ ! -d "$ROOT_PATH/packages/desktop-shell" ]; then
-  exit 0
-fi
-
-if [ "$(git -C "$ROOT_PATH" branch --show-current)" != "main" ]; then
-  echo "Expected CONDUCTOR_ROOT_PATH to point at a main checkout: $ROOT_PATH" >&2
-  exit 1
-fi
-
-copy_dir "$ROOT_PATH/.output" ".output"


### PR DESCRIPTION
This removes the unused .output sync from the Conductor worktree setup script. The setup step now only installs dependencies and copies .env from CONDUCTOR_ROOT_PATH. It also drops the branch-name check that required the root checkout to be on main, which was causing setup to fail for valid checkouts on other branches.