### PR TITLE
feat(auth): require approval before app access

### DIFF
--- a/drizzle/0004_waitlist_user_access.sql
+++ b/drizzle/0004_waitlist_user_access.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user" ADD COLUMN "access_status" text DEFAULT 'pending' NOT NULL;--> statement-breakpoint
+UPDATE "user" SET "access_status" = 'approved';--> statement-breakpoint

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1772878431492,
       "tag": "0002_first_deathstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1772878431493,
+      "tag": "0004_waitlist_user_access",
+      "breakpoints": true
     }
   ]
 }

--- a/src/pages/pending-access-page.tsx
+++ b/src/pages/pending-access-page.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { Github, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { signIn } from "../lib/auth-client";
+
+export function PendingAccessPage() {
+  const [isSigningIn, setIsSigningIn] = useState(false);
+  const [signInError, setSignInError] = useState<string | null>(null);
+
+  const handleRetry = async () => {
+    setSignInError(null);
+    setIsSigningIn(true);
+
+    try {
+      const result = await signIn.social({
+        provider: "github",
+        callbackURL: new URL("/", window.location.origin).toString(),
+      });
+      const error = result?.error;
+
+      if (error) {
+        setSignInError(error.message ?? "Unable to sign in with GitHub. Please try again.");
+        setIsSigningIn(false);
+      }
+    } catch {
+      setSignInError("Unable to sign in with GitHub. Please try again.");
+      setIsSigningIn(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <Card className="neo-enter w-full max-w-sm">
+        <CardContent className="space-y-6 px-6 py-8">
+          <div className="space-y-2 text-center">
+            <h1 className="text-3xl tracking-[0.06em] text-foreground">Access Pending</h1>
+            <p className="text-sm text-muted-foreground">
+              Your account is on the waitlist right now. Once you are approved, sign in again to
+              continue.
+            </p>
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={handleRetry}
+            disabled={isSigningIn}
+          >
+            {isSigningIn ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Checking Access...
+              </>
+            ) : (
+              <>
+                <Github className="h-4 w-4" />
+                Try GitHub Sign-In Again
+              </>
+            )}
+          </Button>
+
+          {signInError ? (
+            <p className="text-center text-sm text-destructive" role="alert">
+              {signInError}
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WebhookRouteImport } from './routes/webhook'
+import { Route as PendingAccessRouteImport } from './routes/pending-access'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as LayoutRouteImport } from './routes/_layout'
 import { Route as LayoutIndexRouteImport } from './routes/_layout.index'
@@ -33,6 +34,11 @@ import { Route as ApiInternalTaskRunsExecutionIdBranchRouteImport } from './rout
 const WebhookRoute = WebhookRouteImport.update({
   id: '/webhook',
   path: '/webhook',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PendingAccessRoute = PendingAccessRouteImport.update({
+  id: '/pending-access',
+  path: '/pending-access',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -139,6 +145,7 @@ const ApiInternalTaskRunsExecutionIdBranchRoute =
 export interface FileRoutesByFullPath {
   '/': typeof LayoutIndexRoute
   '/login': typeof LoginRoute
+  '/pending-access': typeof PendingAccessRoute
   '/webhook': typeof WebhookRoute
   '/settings': typeof LayoutSettingsRoute
   '/runner/$sessionId': typeof LayoutRunnerSessionIdRoute
@@ -159,6 +166,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/login': typeof LoginRoute
+  '/pending-access': typeof PendingAccessRoute
   '/webhook': typeof WebhookRoute
   '/settings': typeof LayoutSettingsRoute
   '/': typeof LayoutIndexRoute
@@ -182,6 +190,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_layout': typeof LayoutRouteWithChildren
   '/login': typeof LoginRoute
+  '/pending-access': typeof PendingAccessRoute
   '/webhook': typeof WebhookRoute
   '/_layout/settings': typeof LayoutSettingsRoute
   '/_layout/': typeof LayoutIndexRoute
@@ -206,6 +215,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/login'
+    | '/pending-access'
     | '/webhook'
     | '/settings'
     | '/runner/$sessionId'
@@ -226,6 +236,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/login'
+    | '/pending-access'
     | '/webhook'
     | '/settings'
     | '/'
@@ -248,6 +259,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/_layout'
     | '/login'
+    | '/pending-access'
     | '/webhook'
     | '/_layout/settings'
     | '/_layout/'
@@ -271,6 +283,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   LayoutRoute: typeof LayoutRouteWithChildren
   LoginRoute: typeof LoginRoute
+  PendingAccessRoute: typeof PendingAccessRoute
   WebhookRoute: typeof WebhookRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiProjectsShapeRoute: typeof ApiProjectsShapeRoute
@@ -293,6 +306,13 @@ declare module '@tanstack/react-router' {
       path: '/webhook'
       fullPath: '/webhook'
       preLoaderRoute: typeof WebhookRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/pending-access': {
+      id: '/pending-access'
+      path: '/pending-access'
+      fullPath: '/pending-access'
+      preLoaderRoute: typeof PendingAccessRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -453,6 +473,7 @@ const LayoutRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
   LoginRoute: LoginRoute,
+  PendingAccessRoute: PendingAccessRoute,
   WebhookRoute: WebhookRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiProjectsShapeRoute: ApiProjectsShapeRoute,

--- a/src/routes/pending-access.tsx
+++ b/src/routes/pending-access.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PendingAccessPage } from "@/pages/pending-access-page";
+
+export const Route = createFileRoute("/pending-access")({
+  component: PendingAccessPage,
+});

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,10 +1,13 @@
 import { betterAuth } from "better-auth";
+import { APIError } from "better-auth/api";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { organization } from "better-auth/plugins";
 import { oAuthProxy } from "better-auth/plugins/oauth-proxy";
-import { eq, and } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import * as schema from "./db/schema";
 import { getDb } from "./db/client";
+import { ensureDefaultOrganizationForUser } from "./lib/ensure-default-organization";
+import { USER_ACCESS_STATUS, isApprovedAccessStatus } from "./lib/user-access";
 
 const PRODUCTION_URL = "https://www.clanki.ai";
 const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
@@ -40,6 +43,10 @@ function isLocalOrigin(origin: string): boolean {
   return LOCAL_HOSTNAMES.has(new URL(origin).hostname);
 }
 
+function isCallbackPath(path: string): boolean {
+  return path.startsWith("/callback") || path.startsWith("/oauth2/callback");
+}
+
 type AuthEnv = {
   DATABASE_URL?: string;
   ENVIRONMENT?: string;
@@ -70,6 +77,18 @@ export function createAuth(env: AuthEnv, request: Request) {
     }),
     secret: env.BETTER_AUTH_SECRET,
     baseURL: origin,
+    user: {
+      additionalFields: {
+        accessStatus: {
+          type: "string",
+          required: false,
+          input: false,
+          returned: false,
+          fieldName: "access_status",
+          defaultValue: USER_ACCESS_STATUS.pending,
+        },
+      },
+    },
     socialProviders: {
       github: {
         clientId: env.GITHUB_CLIENT_ID,
@@ -89,7 +108,35 @@ export function createAuth(env: AuthEnv, request: Request) {
     databaseHooks: {
       session: {
         create: {
-          before: async (session) => {
+          before: async (session, ctx) => {
+            const user = await db.query.user.findFirst({
+              where: eq(schema.user.id, session.userId),
+              columns: {
+                id: true,
+                name: true,
+                email: true,
+                accessStatus: true,
+              },
+            });
+
+            if (!user) {
+              return;
+            }
+
+            if (!isApprovedAccessStatus(user.accessStatus)) {
+              if (ctx && isCallbackPath(ctx.path)) {
+                const pendingAccessUrl = new URL("/pending-access", origin).toString();
+                throw ctx.redirect(pendingAccessUrl);
+              }
+
+              throw new APIError("FORBIDDEN", {
+                message: "Your account is pending approval.",
+                code: "USER_PENDING_APPROVAL",
+              });
+            }
+
+            await ensureDefaultOrganizationForUser({ auth, db, user });
+
             if (session.activeOrganizationId) return;
             const members = await db
               .select({ organizationId: schema.member.organizationId })
@@ -107,37 +154,21 @@ export function createAuth(env: AuthEnv, request: Request) {
       user: {
         create: {
           after: async (user) => {
-            // Check if this user has any pending invitations.
-            // If they do, they signed up via an invite link and should
-            // join the existing org instead of getting a new one.
-            const pending = await db
-              .select({ id: schema.invitation.id })
-              .from(schema.invitation)
-              .where(
-                and(
-                  eq(schema.invitation.email, user.email),
-                  eq(schema.invitation.status, "pending"),
-                ),
-              )
-              .limit(1);
+            const createdUser = await db.query.user.findFirst({
+              where: eq(schema.user.id, user.id),
+              columns: {
+                id: true,
+                name: true,
+                email: true,
+                accessStatus: true,
+              },
+            });
 
-            if (pending.length > 0) {
+            if (!createdUser || !isApprovedAccessStatus(createdUser.accessStatus)) {
               return;
             }
 
-            const slug = user.name
-              .toLowerCase()
-              .replace(/[^a-z0-9]+/g, "-")
-              .replace(/^-|-$/g, "");
-            const uniqueSlug = `${slug}-${user.id.slice(0, 8)}`;
-
-            await auth.api.createOrganization({
-              body: {
-                name: `${user.name}'s Organization`,
-                slug: uniqueSlug,
-                userId: user.id,
-              },
-            });
+            await ensureDefaultOrganizationForUser({ auth, db, user: createdUser });
           },
         },
       },

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -21,6 +21,7 @@ export const user = pgTable("user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("emailVerified").notNull(),
   image: text("image"),
+  accessStatus: text("access_status").notNull().default("pending"),
   createdAt: timestamp("createdAt", { withTimezone: true, mode: "date" }).notNull(),
   updatedAt: timestamp("updatedAt", { withTimezone: true, mode: "date" }).notNull(),
 });

--- a/src/server/lib/ensure-default-organization.ts
+++ b/src/server/lib/ensure-default-organization.ts
@@ -1,0 +1,68 @@
+import { and, eq } from "drizzle-orm";
+import * as schema from "@/server/db/schema";
+
+type OrganizationCreator = {
+  api: {
+    createOrganization(args: {
+      body: {
+        name: string;
+        slug: string;
+        userId: string;
+      };
+    }): Promise<unknown>;
+  };
+};
+
+type DbLike = {
+  select: (...args: any[]) => any;
+};
+
+type UserLike = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+function buildOrganizationSlug(user: UserLike): string {
+  const slug = user.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return `${slug}-${user.id.slice(0, 8)}`;
+}
+
+export async function ensureDefaultOrganizationForUser(args: {
+  auth: OrganizationCreator;
+  db: DbLike;
+  user: UserLike;
+}) {
+  const { auth, db, user } = args;
+
+  const existingMembership = await db
+    .select({ organizationId: schema.member.organizationId })
+    .from(schema.member)
+    .where(eq(schema.member.userId, user.id))
+    .limit(1);
+
+  if (existingMembership.length > 0) {
+    return;
+  }
+
+  const pendingInvitation = await db
+    .select({ id: schema.invitation.id })
+    .from(schema.invitation)
+    .where(and(eq(schema.invitation.email, user.email), eq(schema.invitation.status, "pending")))
+    .limit(1);
+
+  if (pendingInvitation.length > 0) {
+    return;
+  }
+
+  await auth.api.createOrganization({
+    body: {
+      name: `${user.name}'s Organization`,
+      slug: buildOrganizationSlug(user),
+      userId: user.id,
+    },
+  });
+}

--- a/src/server/lib/user-access.ts
+++ b/src/server/lib/user-access.ts
@@ -1,0 +1,10 @@
+export const USER_ACCESS_STATUS = {
+  approved: "approved",
+  pending: "pending",
+} as const;
+
+export function isApprovedAccessStatus(
+  accessStatus: string | null | undefined,
+): accessStatus is typeof USER_ACCESS_STATUS.approved {
+  return accessStatus === USER_ACCESS_STATUS.approved;
+}


### PR DESCRIPTION
Add a waitlist-style approval gate to auth.\n\nNew users are created as pending and are redirected to a pending-access page until their user row is manually approved. Approved users get their default organization on first successful login, and this includes the supporting access-status migration and auth helpers.