### PR TITLE
refactor: remove pointless useEffects

### DIFF
--- a/src/lib/runner-models.ts
+++ b/src/lib/runner-models.ts
@@ -153,13 +153,6 @@ export function serializeRunnerModelSelection(
   return `${selection.provider}:${selection.model}`;
 }
 
-export function selectionsMatch(
-  left: DesktopRunnerModelSelection | null,
-  right: DesktopRunnerModelSelection | null,
-): boolean {
-  return left?.model === right?.model && left?.provider === right?.provider;
-}
-
 function toRunnerModelSelection(option: RunnerModelOption): DesktopRunnerModelSelection {
   return {
     model: option.model,

--- a/src/pages/settings-page.tsx
+++ b/src/pages/settings-page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useLiveQuery } from "@tanstack/react-db";
 import { BookMarked, Loader2, Plus } from "lucide-react";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -21,49 +21,21 @@ export function SettingsPage() {
   const activeOrganization = useOrganization();
 
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [projectSetupDrafts, setProjectSetupDrafts] = useState<Record<string, string>>({});
-  const [projectRunDrafts, setProjectRunDrafts] = useState<Record<string, string>>({});
-  const [projectRunPortDrafts, setProjectRunPortDrafts] = useState<Record<string, string>>({});
+  const [projectSetupEdits, setProjectSetupEdits] = useState<Record<string, string>>({});
+  const [projectRunEdits, setProjectRunEdits] = useState<Record<string, string>>({});
+  const [projectRunPortEdits, setProjectRunPortEdits] = useState<Record<string, string>>({});
   const [savingProjectId, setSavingProjectId] = useState<string | null>(null);
   const [savingProjectRunId, setSavingProjectRunId] = useState<string | null>(null);
   const [projectSetupErrors, setProjectSetupErrors] = useState<Record<string, string>>({});
   const [projectRunErrors, setProjectRunErrors] = useState<Record<string, string>>({});
-  useEffect(() => {
-    setProjectSetupDrafts((previous) => {
-      const next: Record<string, string> = {};
-      for (const project of projects) {
-        next[project.id] = previous[project.id] ?? project.setup_command ?? "";
-      }
-      return next;
-    });
-
-    setProjectRunDrafts((previous) => {
-      const next: Record<string, string> = {};
-      for (const project of projects) {
-        next[project.id] = previous[project.id] ?? project.run_command ?? "";
-      }
-      return next;
-    });
-
-    setProjectRunPortDrafts((previous) => {
-      const next: Record<string, string> = {};
-      for (const project of projects) {
-        next[project.id] =
-          previous[project.id] ??
-          (project.run_port === null || project.run_port === undefined
-            ? ""
-            : String(project.run_port));
-      }
-      return next;
-    });
-  }, [projects]);
 
   async function handleSaveProjectSetupCommand(projectId: string) {
     if (savingProjectId) {
       return;
     }
 
-    const draftValue = projectSetupDrafts[projectId] ?? "";
+    const project = projects.find((p) => p.id === projectId);
+    const draftValue = projectSetupEdits[projectId] ?? project?.setup_command ?? "";
     const setupCommand = draftValue.trim().length > 0 ? draftValue.trim() : null;
 
     setSavingProjectId(projectId);
@@ -75,10 +47,11 @@ export function SettingsPage() {
 
     try {
       await updateProjectSetupCommand({ data: { projectId, setupCommand } });
-      setProjectSetupDrafts((previous) => ({
-        ...previous,
-        [projectId]: setupCommand ?? "",
-      }));
+      setProjectSetupEdits((previous) => {
+        const next = { ...previous };
+        delete next[projectId];
+        return next;
+      });
     } catch (error) {
       setProjectSetupErrors((previous) => ({
         ...previous,
@@ -95,8 +68,13 @@ export function SettingsPage() {
       return;
     }
 
-    const draftRunCommand = projectRunDrafts[projectId] ?? "";
-    const draftRunPort = projectRunPortDrafts[projectId] ?? "";
+    const project = projects.find((p) => p.id === projectId);
+    const draftRunCommand = projectRunEdits[projectId] ?? project?.run_command ?? "";
+    const draftRunPort =
+      projectRunPortEdits[projectId] ??
+      (project?.run_port === null || project?.run_port === undefined
+        ? ""
+        : String(project.run_port));
     const runCommand = draftRunCommand.trim().length > 0 ? draftRunCommand.trim() : null;
     const runPortInput = draftRunPort.trim();
     const runPort = runPortInput.length > 0 ? Number(runPortInput) : null;
@@ -126,14 +104,16 @@ export function SettingsPage() {
 
     try {
       await updateProjectRunCommand({ data: { projectId, runCommand, runPort } });
-      setProjectRunDrafts((previous) => ({
-        ...previous,
-        [projectId]: runCommand ?? "",
-      }));
-      setProjectRunPortDrafts((previous) => ({
-        ...previous,
-        [projectId]: runPort === null ? "" : String(runPort),
-      }));
+      setProjectRunEdits((previous) => {
+        const next = { ...previous };
+        delete next[projectId];
+        return next;
+      });
+      setProjectRunPortEdits((previous) => {
+        const next = { ...previous };
+        delete next[projectId];
+        return next;
+      });
     } catch (error) {
       setProjectRunErrors((previous) => ({
         ...previous,
@@ -210,9 +190,9 @@ export function SettingsPage() {
                         </p>
                         <div className="flex flex-col gap-2 md:flex-row">
                           <Input
-                            value={projectSetupDrafts[project.id] ?? project.setup_command ?? ""}
+                            value={projectSetupEdits[project.id] ?? project.setup_command ?? ""}
                             onChange={(event) =>
-                              setProjectSetupDrafts((previous) => ({
+                              setProjectSetupEdits((previous) => ({
                                 ...previous,
                                 [project.id]: event.target.value,
                               }))
@@ -225,7 +205,7 @@ export function SettingsPage() {
                             disabled={
                               savingProjectId !== null ||
                               (
-                                projectSetupDrafts[project.id] ??
+                                projectSetupEdits[project.id] ??
                                 project.setup_command ??
                                 ""
                               ).trim() === (project.setup_command ?? "")
@@ -250,9 +230,9 @@ export function SettingsPage() {
                         </p>
                         <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_8rem_auto]">
                           <Input
-                            value={projectRunDrafts[project.id] ?? project.run_command ?? ""}
+                            value={projectRunEdits[project.id] ?? project.run_command ?? ""}
                             onChange={(event) =>
-                              setProjectRunDrafts((previous) => ({
+                              setProjectRunEdits((previous) => ({
                                 ...previous,
                                 [project.id]: event.target.value,
                               }))
@@ -264,13 +244,13 @@ export function SettingsPage() {
                             min={1}
                             max={65535}
                             value={
-                              projectRunPortDrafts[project.id] ??
+                              projectRunPortEdits[project.id] ??
                               (project.run_port === null || project.run_port === undefined
                                 ? ""
                                 : String(project.run_port))
                             }
                             onChange={(event) =>
-                              setProjectRunPortDrafts((previous) => ({
+                              setProjectRunPortEdits((previous) => ({
                                 ...previous,
                                 [project.id]: event.target.value,
                               }))
@@ -282,13 +262,10 @@ export function SettingsPage() {
                             onClick={() => void handleSaveProjectRunCommand(project.id)}
                             disabled={
                               savingProjectRunId !== null ||
-                              ((
-                                projectRunDrafts[project.id] ??
-                                project.run_command ??
-                                ""
-                              ).trim() === (project.run_command ?? "") &&
+                              ((projectRunEdits[project.id] ?? project.run_command ?? "").trim() ===
+                                (project.run_command ?? "") &&
                                 (
-                                  projectRunPortDrafts[project.id] ??
+                                  projectRunPortEdits[project.id] ??
                                   (project.run_port === null || project.run_port === undefined
                                     ? ""
                                     : String(project.run_port))

--- a/src/pages/task-page.tsx
+++ b/src/pages/task-page.tsx
@@ -17,7 +17,6 @@ import {
   getDefaultRunnerModelSelection,
   getRunnerModelOptions,
   isRunnerModelSelectionAvailable,
-  selectionsMatch,
   useRunnerModels,
 } from "@/lib/runner-models";
 import {
@@ -167,14 +166,6 @@ export function TaskPage({
     };
   }, [isRunning]);
 
-  useEffect(() => {
-    if (selectionsMatch(selectedModel, activeModelSelection)) {
-      return;
-    }
-
-    setSelectedModel(activeModelSelection);
-  }, [activeModelSelection, selectedModel, setSelectedModel]);
-
   async function handleSend(contentOverride?: string) {
     const content = (contentOverride ?? input).trim();
     if (!content || sending || isRunning || !taskId) return;
@@ -186,9 +177,7 @@ export function TaskPage({
     shouldStickToBottomRef.current = true;
     setSending(true);
     setLocalError(null);
-    if (!selectionsMatch(selectedModel, activeModelSelection)) {
-      setSelectedModel(activeModelSelection);
-    }
+    setSelectedModel(activeModelSelection);
     setLastUsedModel(activeModelSelection);
     if (contentOverride === undefined) {
       setInput("");


### PR DESCRIPTION
Removed two unnecessary useEffect patterns that were causing render cycles:

**task-page**: Removed model sync effect that redundantly wrote activeModelSelection back to session storage. The handleSend function already does this, and the UI already uses the derived activeModelSelection value.

**settings-page**: Replaced useEffect-based draft syncing with inline derivation. Now only user edits are stored in state, with display values derived as edits[id] ?? project.data ?? "". On save success, edits are cleared so they fall back to the updated project data.

Also removed the now-unused selectionsMatch function from runner-models.