### PR TITLE
refactor: move auth guards to route beforeLoad

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,38 +1,18 @@
 import { useEffect, useState } from "react";
-import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
+import { Outlet, useRouterState } from "@tanstack/react-router";
 import { AppQueryProvider } from "@/components/app-query-provider";
 import { cn } from "../lib/utils";
-import { useSession } from "../lib/auth-client";
 import { MobileHeader } from "./layout/mobile-header";
 import { Sidebar } from "./layout/sidebar";
 
 export function Layout() {
-  const { data: session, isPending } = useSession();
-  const navigate = useNavigate();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const pathname = useRouterState({ select: (s) => s.location.pathname });
-
-  useEffect(() => {
-    if (!isPending && !session) {
-      navigate({ to: "/login" });
-    }
-  }, [isPending, session, navigate]);
 
   // Close sidebar on route change (mobile)
   useEffect(() => {
     setSidebarOpen(false);
   }, [pathname]);
-
-  if (isPending) {
-    return (
-      <div className="flex h-dvh items-center justify-center bg-background">
-        <Loader2 className="h-7 w-7 animate-spin text-foreground" />
-      </div>
-    );
-  }
-
-  if (!session) return null;
 
   return (
     <AppQueryProvider>

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -1,13 +1,10 @@
-import { useEffect, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { useState } from "react";
 import { Github, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { signIn, useSession } from "../lib/auth-client";
+import { signIn } from "../lib/auth-client";
 
 export function LoginPage() {
-  const { data: session, isPending } = useSession();
-  const navigate = useNavigate();
   const [isSigningIn, setIsSigningIn] = useState(false);
   const [signInError, setSignInError] = useState<string | null>(null);
 
@@ -31,12 +28,6 @@ export function LoginPage() {
       setIsSigningIn(false);
     }
   };
-
-  useEffect(() => {
-    if (!isPending && session) {
-      navigate({ to: "/" });
-    }
-  }, [isPending, session, navigate]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">

--- a/src/routes/_layout.tsx
+++ b/src/routes/_layout.tsx
@@ -1,7 +1,14 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { Layout } from "@/components/layout";
+import { authClient } from "@/lib/auth-client";
 
 export const Route = createFileRoute("/_layout")({
   ssr: false,
+  beforeLoad: async () => {
+    const { data: session } = await authClient.getSession();
+    if (!session) {
+      throw redirect({ to: "/login" });
+    }
+  },
   component: Layout,
 });

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,6 +1,13 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { LoginPage } from "@/pages/login-page";
+import { authClient } from "@/lib/auth-client";
 
 export const Route = createFileRoute("/login")({
+  beforeLoad: async () => {
+    const { data: session } = await authClient.getSession();
+    if (session) {
+      throw redirect({ to: "/" });
+    }
+  },
   component: LoginPage,
 });


### PR DESCRIPTION
## Summary

Move authentication redirects from component-level `useEffect` to route-level `beforeLoad` handlers. This eliminates flash-of-wrong-content issues and follows TanStack Router best practices.

- `_layout` route: redirect to `/login` if no session
- `login` route: redirect to `/` if already authenticated  
- Remove `useSession` and `useNavigate` from `Layout` and `LoginPage` components
- Remove auth-related loading states and null checks from components

## Changes

- 2 `useEffect`s removed (auth redirects)
- 4 unused imports cleaned up
- Route-level auth guards now execute before any component renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)