### PR TITLE
fix: bundle runner for macOS releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "dev": "vite dev",
     "build:web": "vite build",
-    "build": "bun run build:web && bun run --cwd packages/desktop-shell build && tsc --noEmit",
+    "build": "bun run build:web && bun run --cwd packages/runner build && bun run --cwd packages/desktop-shell build && tsc --noEmit",
     "preview": "vite preview",
     "runner:dev": "bun run --cwd packages/runner dev",
     "electron:start": "bun run build && electron packages/desktop-shell/dist/index.mjs",
@@ -100,16 +100,8 @@
         "to": ".output"
       },
       {
-        "from": "packages/runner/src",
-        "to": "packages/runner/src"
-      },
-      {
-        "from": "node_modules",
-        "to": "node_modules"
-      },
-      {
-        "from": "bun.lock",
-        "to": "bun.lock"
+        "from": "packages/runner/dist",
+        "to": "packages/runner/dist"
       }
     ],
     "mac": {

--- a/packages/desktop-shell/src/desktop-runner.mts
+++ b/packages/desktop-shell/src/desktop-runner.mts
@@ -221,7 +221,7 @@ export function createDesktopRunnerController({
   }
 
   async function startRunner(): Promise<RunnerProcess> {
-    const runnerEntry = path.join(workspaceRoot, "packages/runner/src/cli.ts");
+    const runnerEntry = path.join(workspaceRoot, "packages/runner/dist/cli.mjs");
     if (!fs.existsSync(runnerEntry)) {
       throw new Error(`Runner entry not found at ${runnerEntry}`);
     }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -6,6 +6,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "build": "bun build ./src/cli.ts --target=bun --format=esm --packages=bundle --outfile=./dist/cli.mjs",
     "dev": "bun run ./src/cli.ts"
   },
   "dependencies": {


### PR DESCRIPTION
This updates the desktop release build to bundle the runner into a single dist artifact and package that instead of shipping the runner source plus the full root node_modules tree. The desktop shell now launches packages/runner/dist/cli.mjs, and the root build script generates that bundle before packaging. I verified the change locally with bun run build, bun run package:desktop, bun run format, bun run lint:fix, and bun run knip; the macOS package completed successfully through signing and zip generation.