### PR TITLE
chore: trim runner roadmap from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,12 +153,6 @@ navigate({ to: "/tasks/$taskId", params: { taskId: id } });
 - Always pass `from` (the **route ID**) to `useParams` and `useSearch` so types are inferred. Route IDs include ID-route parent prefixes (e.g. `/layout/...`), while `to` uses URL paths.
 - When adding search params to a route, always add `validateSearch` with sensible defaults so malformed URLs don't crash the app.
 
-## Execution Roadmap
-
-The product direction is to move from Vercel sandboxes to a local runner model built on git worktrees, while preserving a clean path to future remote or self-hosted runners.
-
-The local app shell should be built with `Electron`, not as a pure PWA.
-
 ### System components
 
 The system is split into three main components:
@@ -167,37 +161,9 @@ The system is split into three main components:
 2. **Runner** — a self-hosted runner that (for now) runs on the client's device. Manages sessions, runs code in git worktrees, and performs the real execution operations. Requires `opencode` to be available as a CLI tool on the host machine (manual prerequisite). This is the execution plane.
 3. **Desktop app** — an Electron shell wrapping the Vercel-hosted frontend. This is the primary way users interact with the system. Hosts the local runner and provides native OS integration.
 
-### Architecture direction
-
-- Treat execution as a backend interface, not as a sandbox-specific implementation detail.
-- Prefer the terms `runner`, `execution backend`, `workspace`, and `worktree` in new code and docs. Avoid introducing new sandbox-specific concepts unless touching legacy code that has not been migrated yet.
-- Keep the control plane separate from the execution plane:
-  - control plane (Vercel backend): syncing, persistence, auth, project/PR data
-  - execution plane (runner): repo checkout/worktree lifecycle, process execution, OpenCode session wiring, preview process management
-  - presentation layer (desktop app): UI, task lifecycle views, event history display
-- Keep the current detached task runner and event streaming model backend-agnostic where possible so it can run locally now and remotely later.
-
-### Local-first implementation steps
-
-1. Introduce a runner abstraction in place of the current sandbox-specific API.
-2. Add the `Electron` desktop shell around the existing app and use it as the host for local runner capabilities.
-3. Implement a local worktree runner that can prepare a workspace, execute commands, launch detached processes, read files, and clean up.
-4. Change task execution flow to target the runner abstraction instead of Vercel sandbox primitives.
-5. Replace clone-per-run behavior with cached repo checkout plus per-task git worktrees.
-6. Generalize persisted execution state so it no longer depends on `sandboxId` as the primary concept.
-7. Replace sandbox-only preview, callback, and background-execution assumptions with local equivalents.
-8. Add recovery and cleanup for crashed processes, stale worktrees, and port conflicts.
-
-### Migration stance
-
-- Do not spend time preserving Vercel sandbox compatibility for new runner work unless the user explicitly asks for it.
-- Prefer direct local-runner implementations and clear runner-specific contracts over temporary compatibility layers around sandbox primitives.
-- When migrating legacy sandbox code, optimize for removal and replacement rather than carrying sandbox concepts forward into new packages or APIs.
-
 ### Remote-ready constraints
 
 - Do not hardcode local-only assumptions into the domain model if they would block a remote runner later.
-- Prefer storing runner metadata such as runner type, workspace identifier, workspace path, process identifiers, and preview URL instead of only sandbox identifiers.
 - Keep runner operations small and explicit so the same contract can later be implemented by a daemon on a self-hosted machine.
 - Defer the remote implementation itself for now; design for it, but optimize the current work for the local runner first.
 


### PR DESCRIPTION
Removes the execution roadmap and migration-planning sections from `AGENTS.md`. Keeps the remaining system-components and remote-ready guidance in place while dropping the more prescriptive runner transition details. This narrows the agent instructions to current project constraints instead of an implementation roadmap.