### PR TITLE
Add desktop auto updater

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.1",
+        "electron-updater": "^6.8.3",
         "lucide-react": "^0.563.0",
         "motion": "^12.35.1",
         "nitro": "^3.0.1-alpha.2",
@@ -27,6 +28,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "tailwindcss": "^4.1.18",
         "vite-tsconfig-paths": "^6.1.1",
@@ -1297,6 +1299,8 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.283", "", {}, "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w=="],
 
+    "electron-updater": ["electron-updater@6.8.3", "", { "dependencies": { "builder-util-runtime": "9.5.1", "fs-extra": "^10.1.0", "js-yaml": "^4.1.0", "lazy-val": "^1.0.5", "lodash.escaperegexp": "^4.1.2", "lodash.isequal": "^4.5.0", "semver": "~7.7.3", "tiny-typed-emitter": "^2.1.0" } }, "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ=="],
+
     "electron-winstaller": ["electron-winstaller@5.4.0", "", { "dependencies": { "@electron/asar": "^3.2.1", "debug": "^4.1.1", "fs-extra": "^7.0.1", "lodash": "^4.17.21", "temp": "^0.9.0" }, "optionalDependencies": { "@electron/windows-sign": "^1.1.2" } }, "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -1689,7 +1693,11 @@
 
     "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
 
+    "lodash.escaperegexp": ["lodash.escaperegexp@4.1.2", "", {}, "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="],
+
     "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
+
+    "lodash.isequal": ["lodash.isequal@4.5.0", "", {}, "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="],
 
     "lodash.mergewith": ["lodash.mergewith@4.6.2", "", {}, "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="],
 
@@ -2213,6 +2221,8 @@
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
+
     "sorted-btree": ["sorted-btree@1.8.1", "", {}, "sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -2292,6 +2302,8 @@
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
+    "tiny-typed-emitter": ["tiny-typed-emitter@2.1.0", "", {}, "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="],
 
     "tiny-warning": ["tiny-warning@1.0.3", "", {}, "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="],
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.1",
+    "electron-updater": "^6.8.3",
     "lucide-react": "^0.563.0",
     "motion": "^12.35.1",
     "nitro": "^3.0.1-alpha.2",
@@ -58,6 +59,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "tailwindcss": "^4.1.18",
     "vite-tsconfig-paths": "^6.1.1",
@@ -115,18 +117,19 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "target": [
+        "dmg",
         "zip"
       ]
     },
     "linux": {
       "category": "Development",
       "target": [
-        "zip"
+        "AppImage"
       ]
     },
     "win": {
       "target": [
-        "zip"
+        "nsis"
       ]
     },
     "publish": [

--- a/packages/desktop-shell/src/app-updater.mts
+++ b/packages/desktop-shell/src/app-updater.mts
@@ -1,0 +1,171 @@
+import { app, BrowserWindow } from "electron";
+import { autoUpdater } from "electron-updater";
+
+const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const UPDATE_STATE_CHANNEL = "app-updater:state-changed";
+
+export type AppUpdateState = {
+  availableVersion: string | null;
+  currentVersion: string;
+  status:
+    | "checking"
+    | "downloaded"
+    | "downloading"
+    | "error"
+    | "idle"
+    | "unavailable"
+    | "up-to-date"
+    | "update-available";
+};
+
+type AppUpdaterController = {
+  getState: () => AppUpdateState;
+  quitAndInstall: () => void;
+  start: () => void;
+  stop: () => void;
+};
+
+export function createAppUpdaterController(): AppUpdaterController {
+  let checkForUpdatesPromise: Promise<AppUpdateState> | null = null;
+  let hasStarted = false;
+  let intervalId: NodeJS.Timeout | null = null;
+  let state: AppUpdateState = {
+    availableVersion: null,
+    currentVersion: app.getVersion(),
+    status: app.isPackaged ? "idle" : "unavailable",
+  };
+
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.allowPrerelease = app.getVersion().includes("-");
+
+  autoUpdater.on("checking-for-update", () => {
+    updateState({
+      status: "checking",
+    });
+  });
+
+  autoUpdater.on("update-available", (info) => {
+    updateState({
+      availableVersion: info.version,
+      status: "update-available",
+    });
+  });
+
+  autoUpdater.on("download-progress", () => {
+    updateState({
+      status: "downloading",
+    });
+  });
+
+  autoUpdater.on("update-downloaded", (info) => {
+    updateState({
+      availableVersion: info.version,
+      status: "downloaded",
+    });
+  });
+
+  autoUpdater.on("update-not-available", () => {
+    updateState({
+      availableVersion: null,
+      status: "up-to-date",
+    });
+  });
+
+  autoUpdater.on("error", () => {
+    updateState({
+      status: "error",
+    });
+  });
+
+  function start(): void {
+    if (hasStarted) {
+      return;
+    }
+
+    hasStarted = true;
+
+    if (!app.isPackaged) {
+      broadcastState();
+      return;
+    }
+
+    void checkForUpdates();
+    intervalId = setInterval(() => {
+      void checkForUpdates();
+    }, UPDATE_CHECK_INTERVAL_MS);
+  }
+
+  async function checkForUpdates(): Promise<AppUpdateState> {
+    if (!app.isPackaged) {
+      updateState({
+        status: "unavailable",
+      });
+      return state;
+    }
+
+    if (checkForUpdatesPromise) {
+      return await checkForUpdatesPromise;
+    }
+
+    checkForUpdatesPromise = autoUpdater
+      .checkForUpdates()
+      .then(() => state)
+      .catch(() => {
+        updateState({
+          status: "error",
+        });
+        return state;
+      })
+      .finally(() => {
+        checkForUpdatesPromise = null;
+      });
+
+    return await checkForUpdatesPromise;
+  }
+
+  function quitAndInstall(): void {
+    if (state.status !== "downloaded") {
+      throw new Error("No downloaded update is ready to install.");
+    }
+
+    autoUpdater.quitAndInstall();
+  }
+
+  function getState(): AppUpdateState {
+    return state;
+  }
+
+  function stop(): void {
+    if (intervalId) {
+      clearInterval(intervalId);
+      intervalId = null;
+    }
+  }
+
+  function updateState(nextPartialState: Partial<AppUpdateState>): void {
+    state = {
+      ...state,
+      ...nextPartialState,
+      currentVersion: app.getVersion(),
+    };
+    broadcastState();
+  }
+
+  function broadcastState(): void {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (window.isDestroyed()) {
+        continue;
+      }
+
+      window.webContents.send(UPDATE_STATE_CHANNEL, state);
+    }
+  }
+
+  return {
+    getState,
+    quitAndInstall,
+    start,
+    stop,
+  };
+}

--- a/packages/desktop-shell/src/index.mts
+++ b/packages/desktop-shell/src/index.mts
@@ -2,13 +2,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { app, BrowserWindow, ipcMain, shell } from "electron";
 import { createAppServerController } from "./app-server.mjs";
+import { createAppUpdaterController } from "./app-updater.mjs";
 import { createDesktopRunnerController } from "./desktop-runner.mjs";
 
 const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
 let appServerController: ReturnType<typeof createAppServerController> | null = null;
 let desktopRunnerController: ReturnType<typeof createDesktopRunnerController> | null = null;
+const appUpdaterController = createAppUpdaterController();
 
 let isQuitting = false;
+let isInstallingUpdate = false;
 
 function resolveWorkspaceRoot(): string {
   if (app.isPackaged) {
@@ -59,6 +62,16 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle("desktop-runner:prompt-task", async (_event, args) => {
     return await getDesktopRunnerController().promptRunnerTask(args);
+  });
+
+  ipcMain.handle("app-updater:get-state", () => {
+    return appUpdaterController.getState();
+  });
+
+  ipcMain.handle("app-updater:quit-and-install", async () => {
+    isInstallingUpdate = true;
+    await disposeControllers();
+    appUpdaterController.quitAndInstall();
   });
 }
 
@@ -151,6 +164,7 @@ async function createMainWindow(): Promise<BrowserWindow> {
 }
 
 async function disposeControllers(): Promise<void> {
+  appUpdaterController.stop();
   await Promise.allSettled([appServerController?.stop(), desktopRunnerController?.stop()]);
 }
 
@@ -159,6 +173,7 @@ registerIpcHandlers();
 app
   .whenReady()
   .then(async () => {
+    appUpdaterController.start();
     await createMainWindow();
 
     app.on("activate", async () => {
@@ -181,7 +196,7 @@ app.on("window-all-closed", () => {
 });
 
 app.on("before-quit", (event) => {
-  if (isQuitting) {
+  if (isQuitting || isInstallingUpdate) {
     return;
   }
 

--- a/packages/desktop-shell/src/preload.mts
+++ b/packages/desktop-shell/src/preload.mts
@@ -7,8 +7,21 @@ contextBridge.exposeInMainWorld("clankiDesktop", {
   deleteRunnerWorkspace(workspaceDirectory: string) {
     return ipcRenderer.invoke("desktop-runner:delete-workspace", { workspaceDirectory });
   },
+  getAppUpdateState() {
+    return ipcRenderer.invoke("app-updater:get-state");
+  },
   listRunnerModels(args: { directory: string }) {
     return ipcRenderer.invoke("desktop-runner:list-models", args);
+  },
+  onAppUpdateStateChange(listener: (state: unknown) => void) {
+    const wrappedListener = (_event: unknown, state: unknown) => {
+      listener(state);
+    };
+
+    ipcRenderer.on("app-updater:state-changed", wrappedListener);
+    return () => {
+      ipcRenderer.off("app-updater:state-changed", wrappedListener);
+    };
   },
   openWorkspaceInEditor(args: { editor: "cursor" | "vscode" | "zed"; workspaceDirectory: string }) {
     return ipcRenderer.invoke("desktop-runner:open-workspace-in-editor", args);
@@ -24,5 +37,8 @@ contextBridge.exposeInMainWorld("clankiDesktop", {
     sessionId: string;
   }) {
     return ipcRenderer.invoke("desktop-runner:prompt-task", args);
+  },
+  quitAndInstallAppUpdate() {
+    return ipcRenderer.invoke("app-updater:quit-and-install");
   },
 });

--- a/src/components/desktop-app-updater-toasts.tsx
+++ b/src/components/desktop-app-updater-toasts.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import {
+  getDesktopAppUpdateState,
+  onDesktopAppUpdateStateChange,
+  quitAndInstallDesktopAppUpdate,
+  type DesktopAppUpdateState,
+} from "@/lib/desktop-app-updater";
+import { isDesktopApp } from "@/lib/is-desktop-app";
+
+const UPDATE_READY_TOAST_ID = "desktop-app-update-ready";
+
+export function DesktopAppUpdaterToasts() {
+  const previousStatusRef = useRef<DesktopAppUpdateState["status"] | null>(null);
+
+  useEffect(() => {
+    if (!isDesktopApp()) {
+      return;
+    }
+
+    let active = true;
+
+    const handleUpdateState = (updateState: DesktopAppUpdateState) => {
+      if (!active) {
+        return;
+      }
+
+      const previousStatus = previousStatusRef.current;
+      previousStatusRef.current = updateState.status;
+
+      if (updateState.status === "downloaded" && previousStatus !== "downloaded") {
+        toast("Clanki update ready", {
+          action: {
+            label: "Update Now",
+            onClick: () => {
+              void quitAndInstallDesktopAppUpdate().catch((error) => {
+                toast.error(
+                  error instanceof Error ? error.message : "Failed to install the desktop update",
+                );
+              });
+            },
+          },
+          description: updateState.availableVersion
+            ? `Version ${updateState.availableVersion} has been downloaded and is ready to install.`
+            : "A new Clanki version has been downloaded and is ready to install.",
+          duration: Number.POSITIVE_INFINITY,
+          id: UPDATE_READY_TOAST_ID,
+        });
+        return;
+      }
+
+      if (updateState.status !== "downloaded") {
+        toast.dismiss(UPDATE_READY_TOAST_ID);
+      }
+    };
+
+    void getDesktopAppUpdateState()
+      .then(handleUpdateState)
+      .catch(() => {});
+
+    const unsubscribe = onDesktopAppUpdateStateChange(handleUpdateState);
+
+    return () => {
+      active = false;
+      toast.dismiss(UPDATE_READY_TOAST_ID);
+      unsubscribe();
+    };
+  }, []);
+
+  return null;
+}

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,27 @@
+import { Toaster as Sonner, type ToasterProps } from "sonner";
+import { useTheme } from "@/components/theme-provider";
+
+export function Toaster(props: ToasterProps) {
+  const { theme } = useTheme();
+
+  return (
+    <Sonner
+      closeButton
+      position="top-right"
+      theme={theme}
+      toastOptions={{
+        classNames: {
+          actionButton:
+            "border border-border bg-primary text-primary-foreground shadow-[2px_2px_0_0_var(--color-border)]",
+          cancelButton:
+            "border border-border bg-secondary text-secondary-foreground shadow-[2px_2px_0_0_var(--color-border)]",
+          description: "text-sm text-muted-foreground",
+          toast:
+            "group border border-border bg-card text-card-foreground shadow-[3px_3px_0_0_var(--color-border)]",
+          title: "font-bold tracking-[0.02em]",
+        },
+      }}
+      {...props}
+    />
+  );
+}

--- a/src/lib/clanki-desktop-bridge.ts
+++ b/src/lib/clanki-desktop-bridge.ts
@@ -1,0 +1,78 @@
+type CreateDesktopRunnerSessionResponse = {
+  runnerType: string;
+  sessionId: string;
+  workspaceDirectory: string;
+};
+
+export type DesktopWorkspaceEditor = "cursor" | "vscode" | "zed";
+
+export type DesktopRunnerModelSelection = {
+  model: string;
+  provider: string;
+};
+
+export type DesktopRunnerModelProvider = {
+  id: string;
+  models: Record<string, { id: string; name: string }>;
+  name: string;
+};
+
+export type ListDesktopRunnerModelsResponse = {
+  connected: string[];
+  default: Record<string, string>;
+  providers: DesktopRunnerModelProvider[];
+};
+
+export type DesktopAppUpdateState = {
+  availableVersion: string | null;
+  currentVersion: string;
+  status:
+    | "checking"
+    | "downloaded"
+    | "downloading"
+    | "error"
+    | "idle"
+    | "unavailable"
+    | "up-to-date"
+    | "update-available";
+};
+
+export type ClankiDesktopBridge = {
+  createRunnerSession: (
+    title: string,
+    repoUrl: string,
+  ) => Promise<CreateDesktopRunnerSessionResponse>;
+  deleteRunnerWorkspace: (workspaceDirectory: string) => Promise<void>;
+  getAppUpdateState: () => Promise<DesktopAppUpdateState>;
+  listRunnerModels: (args: { directory: string }) => Promise<ListDesktopRunnerModelsResponse>;
+  onAppUpdateStateChange: (listener: (state: DesktopAppUpdateState) => void) => () => void;
+  openWorkspaceInEditor: (args: {
+    editor: DesktopWorkspaceEditor;
+    workspaceDirectory: string;
+  }) => Promise<void>;
+  promptRunnerTask: (args: {
+    backendBaseUrl: string;
+    callbackToken: string;
+    directory: string;
+    executionId: string;
+    model?: string;
+    prompt: string;
+    provider?: string;
+    sessionId: string;
+  }) => Promise<void>;
+  quitAndInstallAppUpdate: () => Promise<void>;
+};
+
+declare global {
+  interface Window {
+    clankiDesktop?: ClankiDesktopBridge;
+  }
+}
+
+export function getClankiDesktopBridge(): ClankiDesktopBridge {
+  if (typeof window === "undefined" || !window.clankiDesktop) {
+    throw new Error("The desktop bridge is only available in the Electron app.");
+  }
+
+  return window.clankiDesktop;
+}

--- a/src/lib/desktop-app-updater.ts
+++ b/src/lib/desktop-app-updater.ts
@@ -1,0 +1,17 @@
+import { getClankiDesktopBridge, type DesktopAppUpdateState } from "@/lib/clanki-desktop-bridge";
+
+export type { DesktopAppUpdateState };
+
+export async function getDesktopAppUpdateState(): Promise<DesktopAppUpdateState> {
+  return await getClankiDesktopBridge().getAppUpdateState();
+}
+
+export function onDesktopAppUpdateStateChange(
+  listener: (state: DesktopAppUpdateState) => void,
+): () => void {
+  return getClankiDesktopBridge().onAppUpdateStateChange(listener);
+}
+
+export async function quitAndInstallDesktopAppUpdate(): Promise<void> {
+  await getClankiDesktopBridge().quitAndInstallAppUpdate();
+}

--- a/src/lib/desktop-runner.ts
+++ b/src/lib/desktop-runner.ts
@@ -1,87 +1,38 @@
-type CreateDesktopRunnerSessionResponse = {
-  runnerType: string;
-  sessionId: string;
-  workspaceDirectory: string;
+import {
+  getClankiDesktopBridge,
+  type DesktopRunnerModelSelection,
+  type DesktopWorkspaceEditor,
+  type ListDesktopRunnerModelsResponse,
+} from "@/lib/clanki-desktop-bridge";
+
+export type {
+  DesktopRunnerModelSelection,
+  DesktopWorkspaceEditor,
+  ListDesktopRunnerModelsResponse,
 };
-
-export type DesktopWorkspaceEditor = "cursor" | "vscode" | "zed";
-
-export type DesktopRunnerModelSelection = {
-  model: string;
-  provider: string;
-};
-
-export type DesktopRunnerModelProvider = {
-  id: string;
-  models: Record<string, { id: string; name: string }>;
-  name: string;
-};
-
-export type ListDesktopRunnerModelsResponse = {
-  connected: string[];
-  default: Record<string, string>;
-  providers: DesktopRunnerModelProvider[];
-};
-
-type DesktopRunnerBridge = {
-  createRunnerSession: (
-    title: string,
-    repoUrl: string,
-  ) => Promise<CreateDesktopRunnerSessionResponse>;
-  deleteRunnerWorkspace: (workspaceDirectory: string) => Promise<void>;
-  listRunnerModels: (args: { directory: string }) => Promise<ListDesktopRunnerModelsResponse>;
-  openWorkspaceInEditor: (args: {
-    editor: DesktopWorkspaceEditor;
-    workspaceDirectory: string;
-  }) => Promise<void>;
-  promptRunnerTask: (args: {
-    backendBaseUrl: string;
-    callbackToken: string;
-    directory: string;
-    executionId: string;
-    model?: string;
-    prompt: string;
-    provider?: string;
-    sessionId: string;
-  }) => Promise<void>;
-};
-
-declare global {
-  interface Window {
-    clankiDesktop?: DesktopRunnerBridge;
-  }
-}
-
-function getDesktopRunnerBridge(): DesktopRunnerBridge {
-  if (typeof window === "undefined" || !window.clankiDesktop) {
-    throw new Error("The desktop runner API is only available in the Electron app.");
-  }
-
-  return window.clankiDesktop;
-}
 
 export async function createDesktopRunnerSession(
   title: string,
   repoUrl: string,
 ): Promise<{ runnerType: string; sessionId: string; workspaceDirectory: string }> {
-  return await getDesktopRunnerBridge().createRunnerSession(title, repoUrl);
+  return await getClankiDesktopBridge().createRunnerSession(title, repoUrl);
 }
 
 export async function deleteDesktopRunnerWorkspace(workspaceDirectory: string): Promise<void> {
-  await getDesktopRunnerBridge().deleteRunnerWorkspace(workspaceDirectory);
+  await getClankiDesktopBridge().deleteRunnerWorkspace(workspaceDirectory);
 }
 
 export async function listDesktopRunnerModels(args: {
   directory: string;
 }): Promise<ListDesktopRunnerModelsResponse> {
-  return await getDesktopRunnerBridge().listRunnerModels(args);
+  return await getClankiDesktopBridge().listRunnerModels(args);
 }
 
 export async function openDesktopWorkspaceInEditor(args: {
   editor: DesktopWorkspaceEditor;
   workspaceDirectory: string;
 }): Promise<void> {
-  await getDesktopRunnerBridge().openWorkspaceInEditor(args);
+  await getClankiDesktopBridge().openWorkspaceInEditor(args);
 }
 
 export async function promptDesktopRunnerTask(args: {
@@ -94,5 +45,5 @@ export async function promptDesktopRunnerTask(args: {
   provider?: string;
   sessionId: string;
 }): Promise<void> {
-  await getDesktopRunnerBridge().promptRunnerTask(args);
+  await getClankiDesktopBridge().promptRunnerTask(args);
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,7 +1,9 @@
 /// <reference types="vite/client" />
 import { HeadContent, Outlet, Scripts, createRootRoute } from "@tanstack/react-router";
 import type { ReactNode } from "react";
+import { DesktopAppUpdaterToasts } from "@/components/desktop-app-updater-toasts";
 import { ThemeProvider } from "@/components/theme-provider";
+import { Toaster } from "@/components/ui/sonner";
 import { themeInitializationScript } from "@/lib/theme";
 import appCss from "@/index.css?url";
 
@@ -32,6 +34,8 @@ function RootDocument({ children }: { children: ReactNode }) {
       <body>
         <ThemeProvider>
           {children}
+          <DesktopAppUpdaterToasts />
+          <Toaster />
           <Scripts />
         </ThemeProvider>
       </body>


### PR DESCRIPTION
## Summary
Add an Electron auto-updater backed by GitHub Releases, including the main-process updater controller and the desktop bridge methods needed to install a downloaded update.
Mount a global Sonner toaster and show a persistent desktop-only "Update Now" toast when an update is ready.
Update desktop packaging targets to updater-compatible formats and add the required runtime dependencies.

## Verification
bun run format
bun run lint:fix
bun run knip
bun run build