### PR TITLE
fix(sidebar): rename open-without-pr state to idle

### DIFF
--- a/src/lib/task-sidebar.ts
+++ b/src/lib/task-sidebar.ts
@@ -10,7 +10,7 @@ export type TaskSidebarGroup = "merged" | "needsAction" | "openNoPr" | "awaiting
 export const TASK_SIDEBAR_GROUPS: Array<{ key: TaskSidebarGroup; label: string }> = [
   { key: "merged", label: "Merged" },
   { key: "needsAction", label: "Needs action" },
-  { key: "openNoPr", label: "Open (no PR)" },
+  { key: "openNoPr", label: "Idle" },
   { key: "awaitingReview", label: "Awaiting review" },
   { key: "running", label: "Running" },
 ];


### PR DESCRIPTION
## Summary
- replace the sidebar label for tasks without a pull request from `Open (no PR)` to `Idle`
- keep the existing grouping key and behavior unchanged so this is a copy-only update