### PR TITLE
Fix duplicate new task hotkey

### DIFF
--- a/src/components/layout/task-list.tsx
+++ b/src/components/layout/task-list.tsx
@@ -112,6 +112,7 @@ export function TaskList() {
           variant="ghost"
           size="icon-xs"
           iconOnly
+          hotkeyEnabled
           className="text-muted-foreground shadow-none hover:border-transparent hover:shadow-none"
         />
       </div>

--- a/src/components/new-task-button.tsx
+++ b/src/components/new-task-button.tsx
@@ -14,9 +14,14 @@ type ButtonProps = ComponentProps<typeof Button>;
 
 type NewTaskButtonProps = Omit<ButtonProps, "children" | "disabled" | "onClick"> & {
   iconOnly?: boolean;
+  hotkeyEnabled?: boolean;
 };
 
-export function NewTaskButton({ iconOnly = false, ...props }: NewTaskButtonProps) {
+export function NewTaskButton({
+  iconOnly = false,
+  hotkeyEnabled = false,
+  ...props
+}: NewTaskButtonProps) {
   const navigate = useNavigate();
   const [creating, setCreating] = useState(false);
   const { data: projects } = useLiveQuery((query) =>
@@ -25,7 +30,7 @@ export function NewTaskButton({ iconOnly = false, ...props }: NewTaskButtonProps
 
   const [defaultProject] = projects;
 
-  useHotkey(hotkeys.newTask.keys, () => handleNewTask());
+  useHotkey(hotkeys.newTask.keys, () => handleNewTask(), { enabled: hotkeyEnabled });
 
   function handleNewTask() {
     const repoUrl = defaultProject?.repo_url;


### PR DESCRIPTION
This scopes the Mod+N new-task shortcut so only one NewTaskButton instance registers it at a time. The sidebar button remains the active global registration, and the button component now gates the hotkey through TanStack Hotkeys' enabled option. Validation: bun run format, bun run lint:fix, and bun run knip.