### PR TITLE
Make workspace setup explicit during task bootstrap

### DIFF
--- a/drizzle/0005_task_setup_status.sql
+++ b/drizzle/0005_task_setup_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "tasks" ADD COLUMN "setup_status" text DEFAULT 'ready' NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1772878431493,
       "tag": "0004_waitlist_user_access",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1773179000000,
+      "tag": "0005_task_setup_status",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/runner/src/local-runner-client.ts
+++ b/packages/runner/src/local-runner-client.ts
@@ -13,6 +13,8 @@ import type {
   LocalRunnerInfoResponse,
   PromptAssistantSessionRequest,
   PromptAssistantSessionResponse,
+  RunWorkspaceSetupRequest,
+  RunWorkspaceSetupResponse,
 } from "./local-runner-protocol";
 
 export function createLocalRunnerClient(baseUrl: string) {
@@ -60,6 +62,9 @@ export function createLocalRunnerClient(baseUrl: string) {
       body: PromptAssistantSessionRequest,
     ): Promise<PromptAssistantSessionResponse> {
       return await postJson(`${normalizedBaseUrl}/assistant/session/prompt`, body);
+    },
+    async runWorkspaceSetup(body: RunWorkspaceSetupRequest): Promise<RunWorkspaceSetupResponse> {
+      return await postJson(`${normalizedBaseUrl}/workspace/setup`, body);
     },
   };
 }

--- a/packages/runner/src/local-runner-protocol.ts
+++ b/packages/runner/src/local-runner-protocol.ts
@@ -38,6 +38,15 @@ export type CreateAssistantSessionResponse = {
   workspaceDirectory: string;
 };
 
+export type RunWorkspaceSetupRequest = {
+  setupCommand: string;
+  workspaceDirectory: string;
+};
+
+export type RunWorkspaceSetupResponse = {
+  ok: true;
+};
+
 export type EnsureAssistantSessionRequest = {
   directory: string;
   model?: string;

--- a/packages/runner/src/local-runner-server.ts
+++ b/packages/runner/src/local-runner-server.ts
@@ -12,10 +12,11 @@ import {
   type ListOpencodeModelsRequest,
   type PromptAssistantSessionRequest,
   type PromptTaskAssistantSessionRequest,
+  type RunWorkspaceSetupRequest,
 } from "./local-runner-protocol";
 import { listOpencodeModels } from "./opencode-models";
 import { promptTaskAssistantSession } from "./task-assistant-session";
-import { createWorkspace, deleteWorkspace } from "./workspace";
+import { createWorkspace, deleteWorkspace, runWorkspaceSetup } from "./workspace";
 
 export type LocalRunnerServerOptions = {
   host?: string;
@@ -120,6 +121,14 @@ export function createLocalRunnerApp(): Hono {
     const body = await readJson<DeleteWorkspaceRequest>(c);
 
     deleteWorkspace(body.workspaceDirectory);
+
+    return c.json({ ok: true });
+  });
+
+  app.post("/workspace/setup", async (c) => {
+    const body = await readJson<RunWorkspaceSetupRequest>(c);
+
+    runWorkspaceSetup(body);
 
     return c.json({ ok: true });
   });

--- a/packages/runner/src/workspace.ts
+++ b/packages/runner/src/workspace.ts
@@ -47,6 +47,28 @@ export function deleteWorkspace(workspaceDirectory: string): void {
   );
 }
 
+export function runWorkspaceSetup(args: {
+  setupCommand: string;
+  workspaceDirectory: string;
+}): void {
+  const managedWorkspaceDirectory = resolveManagedWorkspaceDirectory(args.workspaceDirectory);
+  const setupCommand = args.setupCommand.trim();
+
+  if (setupCommand.length === 0) {
+    return;
+  }
+
+  if (!fs.existsSync(managedWorkspaceDirectory)) {
+    throw new Error(`Workspace does not exist: ${args.workspaceDirectory}`);
+  }
+
+  runShellCommand(
+    setupCommand,
+    managedWorkspaceDirectory,
+    `Failed to run workspace setup in ${managedWorkspaceDirectory}`,
+  );
+}
+
 function prepareSessionWorktree(repoUrl: string, title: string): PreparedWorkspace {
   const workspace = resolveRepoWorkspacePaths(repoUrl);
   const defaultBranch = ensureDefaultCheckout(repoUrl, workspace);
@@ -268,4 +290,34 @@ function runCommand(program: string, args: string[], errorContext?: string): str
   }
 
   throw new Error(`Command ${program} failed: ${details}`);
+}
+
+function runShellCommand(command: string, cwd: string, errorContext?: string): string {
+  const output = spawnSync(command, {
+    cwd,
+    encoding: "utf8",
+    shell: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (output.error) {
+    const message = errorContext
+      ? `${errorContext}: ${output.error.message}`
+      : `Failed to run command: ${output.error.message}`;
+    throw new Error(message);
+  }
+
+  if (output.status === 0) {
+    return output.stdout;
+  }
+
+  const stderr = output.stderr.trim();
+  const stdout = output.stdout.trim();
+  const details = stderr || stdout || `exit status ${output.status}`;
+
+  if (errorContext) {
+    throw new Error(`${errorContext}: ${details}`);
+  }
+
+  throw new Error(`Command failed: ${details}`);
 }

--- a/src/components/new-task-button.tsx
+++ b/src/components/new-task-button.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Kbd } from "@/components/ui/kbd";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { projectsCollection, tasksCollection } from "@/lib/collections";
-import { createDesktopRunnerSession } from "@/lib/desktop-runner";
+import { createDesktopRunnerSession, runDesktopWorkspaceSetup } from "@/lib/desktop-runner";
 import { hotkeys } from "@/lib/hotkeys";
 
 type ButtonProps = ComponentProps<typeof Button>;
@@ -29,6 +29,7 @@ export function NewTaskButton({ iconOnly = false, ...props }: NewTaskButtonProps
 
   function handleNewTask() {
     const repoUrl = defaultProject?.repo_url;
+    const setupCommand = defaultProject?.setup_command?.trim() ?? "";
     if (creating || !defaultProject || !repoUrl) {
       return;
     }
@@ -44,6 +45,7 @@ export function NewTaskButton({ iconOnly = false, ...props }: NewTaskButtonProps
       project_id: defaultProject.id,
       title: taskTitle,
       status: "open",
+      setup_status: "worktree-setup",
       stream_id: null,
       branch: null,
       runner_type: null,
@@ -58,11 +60,25 @@ export function NewTaskButton({ iconOnly = false, ...props }: NewTaskButtonProps
     setCreating(false);
 
     createDesktopRunnerSession(taskTitle, repoUrl)
-      .then((response) => {
+      .then(async (response) => {
         tasksCollection.update(taskId, (draft) => {
           draft.runner_type = response.runnerType;
           draft.runner_session_id = response.sessionId;
           draft.workspace_path = response.workspaceDirectory;
+          draft.setup_status = setupCommand.length > 0 ? "installing" : "ready";
+        });
+
+        if (setupCommand.length === 0) {
+          return;
+        }
+
+        await runDesktopWorkspaceSetup({
+          setupCommand,
+          workspaceDirectory: response.workspaceDirectory,
+        });
+
+        tasksCollection.update(taskId, (draft) => {
+          draft.setup_status = "ready";
         });
       })
       .catch((err) => {

--- a/src/components/task-page-input.tsx
+++ b/src/components/task-page-input.tsx
@@ -59,9 +59,11 @@ export function TaskPageInput({
           placeholder={
             isReadOnlyRemoteTask
               ? "This runner-backed task is read-only on this device."
-              : isRunning
-                ? "Wait for the current run to finish..."
-                : "Send a message..."
+              : preparingWorkspace
+                ? "Wait for workspace setup to finish..."
+                : isRunning
+                  ? "Wait for the current run to finish..."
+                  : "Send a message..."
           }
           rows={4}
           disabled={isRunning || isReadOnlyRemoteTask || sending}

--- a/src/lib/collections.ts
+++ b/src/lib/collections.ts
@@ -24,6 +24,7 @@ const taskSchema = z.object({
   project_id: z.string().nullable(),
   title: z.string(),
   status: z.string(),
+  setup_status: z.string(),
   runner_type: z.string().nullable(),
   runner_session_id: z.string().nullable(),
   stream_id: z.string().nullable(),
@@ -78,6 +79,7 @@ function txidsToMatch(txids: Array<number>) {
 
 const taskFieldMap: Record<string, keyof Partial<Task>> = {
   title: "title",
+  setupStatus: "setup_status",
   runnerType: "runner_type",
   runnerSessionId: "runner_session_id",
   workspacePath: "workspace_path",
@@ -155,6 +157,7 @@ function createCollections(baseUrl: string) {
               projectId: task.project_id,
               runnerSessionId: task.runner_session_id ?? undefined,
               runnerType: task.runner_type ?? undefined,
+              setupStatus: task.setup_status,
               status: task.status,
               workspacePath: task.workspace_path ?? undefined,
               createdAt: Number(task.created_at),

--- a/src/lib/desktop-runner.ts
+++ b/src/lib/desktop-runner.ts
@@ -44,6 +44,7 @@ type DesktopRunnerBridge = {
     provider?: string;
     sessionId: string;
   }) => Promise<void>;
+  runWorkspaceSetup: (args: { setupCommand: string; workspaceDirectory: string }) => Promise<void>;
 };
 
 declare global {
@@ -95,4 +96,11 @@ export async function promptDesktopRunnerTask(args: {
   sessionId: string;
 }): Promise<void> {
   await getDesktopRunnerBridge().promptRunnerTask(args);
+}
+
+export async function runDesktopWorkspaceSetup(args: {
+  setupCommand: string;
+  workspaceDirectory: string;
+}): Promise<void> {
+  await getDesktopRunnerBridge().runWorkspaceSetup(args);
 }

--- a/src/pages/task-page.tsx
+++ b/src/pages/task-page.tsx
@@ -50,6 +50,7 @@ export interface TaskPageProps {
   title: string;
   error: string | null;
   isRunning: boolean;
+  setupStatus: string;
   runnerSessionId: string | null;
   runnerType: string | null;
   workspacePath: string | null;
@@ -64,6 +65,7 @@ export function TaskPage({
   pullRequest,
   error,
   isRunning,
+  setupStatus,
   runnerSessionId,
   runnerType,
   workspacePath,
@@ -113,6 +115,7 @@ export function TaskPage({
   const isRunnerBackedTask =
     runnerType === "local-worktree" && !!runnerSessionId && !!workspacePath;
   const willBeRunnerBacked = desktopApp && (!runnerType || isRunnerBackedTask);
+  const setupStatusLabel = getSetupStatusLabel(setupStatus);
   const isReadOnlyRemoteTask = isRunnerBackedTask && !desktopApp;
   const {
     data: runnerModels,
@@ -131,6 +134,8 @@ export function TaskPage({
   const runnerModelErrorMessage =
     runnerModelsError instanceof Error ? runnerModelsError.message : null;
   const displayError = localError ?? error;
+  const preparingWorkspace =
+    willBeRunnerBacked && !displayError && (!isRunnerBackedTask || setupStatus !== "ready");
 
   useEffect(() => {
     if (!shouldStickToBottomRef.current) {
@@ -283,6 +288,15 @@ export function TaskPage({
         </div>
       ) : null}
 
+      {preparingWorkspace ? (
+        <div className="shrink-0 border-b border-border bg-muted/40 px-4 py-2.5 md:px-6">
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Workspace status: {setupStatusLabel}</span>
+          </div>
+        </div>
+      ) : null}
+
       <TaskPageMessageList
         messageListRef={messageListRef}
         messagesEndRef={messagesEndRef}
@@ -301,7 +315,7 @@ export function TaskPage({
         isRunning={isRunning}
         isReadOnlyRemoteTask={isReadOnlyRemoteTask}
         sending={sending}
-        preparingWorkspace={willBeRunnerBacked && !isRunnerBackedTask}
+        preparingWorkspace={preparingWorkspace}
         isRunnerBackedTask={isRunnerBackedTask}
         willBeRunnerBacked={willBeRunnerBacked}
         activeModelSelection={activeModelSelection}
@@ -315,4 +329,15 @@ export function TaskPage({
       />
     </div>
   );
+}
+
+function getSetupStatusLabel(setupStatus: string): string {
+  switch (setupStatus) {
+    case "worktree-setup":
+      return "Setting up worktree";
+    case "installing":
+      return "Running project setup";
+    default:
+      return "Ready";
+  }
 }

--- a/src/routes/_layout.tasks.$taskId.tsx
+++ b/src/routes/_layout.tasks.$taskId.tsx
@@ -82,6 +82,7 @@ export const Route = createFileRoute("/_layout/tasks/$taskId")({
         }
         error={openedTask?.task.error ?? null}
         isRunning={(openedTask?.task.status ?? "") === "running"}
+        setupStatus={openedTask?.task.setup_status ?? "ready"}
         runnerSessionId={openedTask?.task.runner_session_id ?? null}
         runnerType={openedTask?.task.runner_type ?? null}
         workspacePath={openedTask?.task.workspace_path ?? null}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -233,6 +233,7 @@ export const tasks = pgTable(
     projectId: text("project_id").references(() => projects.id, { onDelete: "set null" }),
     title: text("title").notNull(),
     status: text("status").notNull().default("open"),
+    setupStatus: text("setup_status").notNull().default("ready"),
     branch: text("branch"),
     runnerType: text("runner_type"),
     runnerSessionId: text("runner_session_id"),

--- a/src/server/functions/tasks.ts
+++ b/src/server/functions/tasks.ts
@@ -40,6 +40,7 @@ export const createTask = createServerFn({ method: "POST" })
       projectId: z.string(),
       runnerSessionId: z.string().optional(),
       runnerType: z.string().optional(),
+      setupStatus: z.string().optional(),
       status: z.string().optional(),
       workspacePath: z.string().optional(),
       createdAt: z.number().optional(),
@@ -78,6 +79,10 @@ export const createTask = createServerFn({ method: "POST" })
         typeof input.status === "string" && input.status.trim().length > 0
           ? input.status.trim()
           : "open";
+      const setupStatus =
+        typeof input.setupStatus === "string" && input.setupStatus.trim().length > 0
+          ? input.setupStatus.trim()
+          : "ready";
       const taskId = parseOptionalId(input.id) ?? crypto.randomUUID();
 
       const streamId = await createStream({
@@ -92,6 +97,7 @@ export const createTask = createServerFn({ method: "POST" })
         projectId: input.projectId,
         title: input.title.trim(),
         status,
+        setupStatus,
         runnerSessionId: parseOptionalId(input.runnerSessionId) ?? null,
         runnerType:
           typeof input.runnerType === "string" && input.runnerType.trim().length > 0
@@ -121,6 +127,7 @@ export const updateTask = createServerFn({ method: "POST" })
       title: z.string().optional(),
       runnerSessionId: z.string().nullable().optional(),
       runnerType: z.string().nullable().optional(),
+      setupStatus: z.string().optional(),
       workspacePath: z.string().nullable().optional(),
       error: z.string().nullable().optional(),
     }),


### PR DESCRIPTION
## Summary
- add a persisted task `setup_status` so runner-backed tasks can move through `worktree-setup`, `installing`, and `ready`
- run each project's saved setup command during workspace creation through the local runner and update task state as it progresses
- show setup progress in the task UI and block input until the workspace is ready